### PR TITLE
Fix GitHub App secrets in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,8 +12,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.STATION_UPDATE_APP_ID }}
-          private-key: ${{ secrets.STATION_UPDATE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.PR_AUTO_MERGER_APP_PRIVATE_KEY }}
 
       - name: Dependabot metadata
         id: metadata
@@ -38,8 +38,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.STATION_UPDATE_APP_ID }}
-          private-key: ${{ secrets.STATION_UPDATE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PR_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.PR_AUTO_MERGER_APP_PRIVATE_KEY }}
 
       - name: Approve a PR
         run: |


### PR DESCRIPTION
- Use PR_AUTO_MERGER_APP for auto-merge functionality
- Separate from STATION_UPDATE_APP used for data updates
- Ensure proper app permissions for each automation purpose

🤖 Generated with [Claude Code](https://claude.ai/code)