### PR TITLE
Lift GeoJSON data fetching to parent component

### DIFF
--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -2,12 +2,14 @@ import { useEffect, useRef } from 'react';
 
 import { createRoadStation } from '../road-station';
 import { StyleManager } from '../style-manager';
+import { StationsGeoJSON } from '../types/geojson';
 
 interface MarkersProps {
     map: google.maps.Map | null;
     selectedFeature: google.maps.Data.Feature | null;
     onFeatureSelect: (feature: google.maps.Data.Feature | null) => void;
     styleManager: StyleManager;
+    stations: StationsGeoJSON | null;
 }
 
 export function Markers(props: MarkersProps) {
@@ -18,25 +20,18 @@ export function Markers(props: MarkersProps) {
     }, [props.selectedFeature]);
 
     useEffect(() => {
-        if (!props.map) return;
+        if (!props.map || !props.stations) return;
 
-        const loadGeoJSON = async () => {
-            const response = await fetch('../data/stations.geojson');
-            const stations = await response.json();
-            
-            // Set up markers
-            props.map!.data.addGeoJson(stations);
-            props.map!.data.addListener('click', onMarkerClick);
-            props.map!.data.addListener('dblclick', onMarkerDoubleClick);
-            props.map!.data.addListener('rightclick', onMarkerRightClick);
-            props.map!.data.setStyle((feature: google.maps.Data.Feature) => {
-                const station = createRoadStation(feature);
-                return props.styleManager.getStyle(station);
-            });
-        };
-
-        loadGeoJSON();
-    }, [props.map]);
+        // Set up markers
+        props.map.data.addGeoJson(props.stations);
+        props.map.data.addListener('click', onMarkerClick);
+        props.map.data.addListener('dblclick', onMarkerDoubleClick);
+        props.map.data.addListener('rightclick', onMarkerRightClick);
+        props.map.data.setStyle((feature: google.maps.Data.Feature) => {
+            const station = createRoadStation(feature);
+            return props.styleManager.getStyle(station);
+        });
+    }, [props.map, props.stations]);
 
     const onMarkerClick = (event: google.maps.Data.MouseEvent) => {
         if (props.map && selectedFeatureRef.current === event.feature) {

--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -3,6 +3,7 @@ import { InfoWindow } from './InfoWindow';
 import { ClipboardButton } from './ClipboardButton';
 import { Markers } from './Markers';
 import { getStyleManagerInstance } from '../style-manager';
+import { StationsGeoJSON } from '../types/geojson';
 
 const getCurrentPosition = (): Promise<GeolocationPosition> => {
     return new Promise((resolve) => {
@@ -14,6 +15,7 @@ export function RoadStationMap() {
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const [map, setMap] = useState<google.maps.Map | null>(null);
     const [feature, setFeature] = useState<google.maps.Data.Feature | null>(null);
+    const [stations, setStations] = useState<StationsGeoJSON | null>(null);
     const styleManager = getStyleManagerInstance();
 
     useEffect(() => {
@@ -24,6 +26,20 @@ export function RoadStationMap() {
             });
             setMap(mapInstance);
         }
+    }, []);
+
+    // Fetch stations data once
+    useEffect(() => {
+        const fetchStations = async () => {
+            try {
+                const response = await fetch('../data/stations.geojson');
+                const data = await response.json();
+                setStations(data);
+            } catch (error) {
+                console.error('Error fetching stations:', error);
+            }
+        };
+        fetchStations();
     }, []);
 
     useEffect(() => {
@@ -48,6 +64,7 @@ export function RoadStationMap() {
                 selectedFeature={feature}
                 onFeatureSelect={setFeature}
                 styleManager={styleManager}
+                stations={stations}
             />
             <InfoWindow
                 selectedFeature={feature}

--- a/src/frontend/types/geojson.ts
+++ b/src/frontend/types/geojson.ts
@@ -1,0 +1,23 @@
+export interface StationProperties {
+    stationId: string;
+    name: string;
+    address: string;
+    hours: string;
+    uri: string;
+    mapcode: string;
+    prefId: string;
+}
+
+export interface StationFeature {
+    type: 'Feature';
+    geometry: {
+        type: 'Point';
+        coordinates: [number, number]; // [longitude, latitude]
+    };
+    properties: StationProperties;
+}
+
+export interface StationsGeoJSON {
+    type: 'FeatureCollection';
+    features: StationFeature[];
+}


### PR DESCRIPTION
- Move data fetching logic from Markers to RoadStationMap component
- Add TypeScript type definitions for GeoJSON station data
- Pass stations data as props to improve component testability

This refactoring centralizes data management in the parent component, making the Markers component more focused and easier to test.

🤖 Generated with [Claude Code](https://claude.ai/code)