### PR TITLE
Refactor serialization with symmetric deserialize implementation

### DIFF
--- a/src/frontend/storage/query-storage.test.ts
+++ b/src/frontend/storage/query-storage.test.ts
@@ -3,10 +3,6 @@
  */
 import { describe, it, expect } from 'vitest';
 import { QueryStorage } from './query-storage';
-import { createMockStations } from '../../test-utils/test-utils';
-
-// Create default mock stations for most tests
-const mockStations = createMockStations(3);
 
 describe('QueryStorage', () => {
 
@@ -85,55 +81,6 @@ describe('QueryStorage', () => {
   });
 
 
-  describe('loadFromQueries', () => {
-    it('should process queries after stations data is set', () => {
-      const queryStorage = new QueryStorage();
-      
-      // Load queries first (they will be pending)
-      queryStorage.loadFromQueries({
-        c1: 'AQ==', // Base64 for [1] - represents internalId 0
-        c2: 'Ag==', // Base64 for [2] - represents internalId 1
-      });
-
-      // Queries should not be accessible yet
-      expect(queryStorage.getItem('18786')).toBeNull();
-      expect(queryStorage.getItem('18787')).toBeNull();
-
-      // Set stations data to trigger processing
-      queryStorage.setStationsData(mockStations);
-
-      // Now queries should be processed and stations mapped
-      expect(queryStorage.getItem('18786')).toBe('1'); // internalId 0 -> stationId 18786
-      expect(queryStorage.getItem('18787')).toBe('2'); // internalId 1 -> stationId 18787
-    });
-
-    it('should handle empty queries', () => {
-      const queryStorage = new QueryStorage();
-      
-      queryStorage.loadFromQueries({});
-      queryStorage.setStationsData(mockStations);
-      
-      expect(queryStorage.listItems()).toEqual([]);
-    });
-
-    it('should handle queries with all style types', () => {
-      const queryStorage = new QueryStorage();
-      
-      // Create queries for all 4 styles with different stations
-      queryStorage.loadFromQueries({
-        c1: 'AQ==', // Base64 for [1] - internalId 0
-        c2: 'Ag==', // Base64 for [2] - internalId 1  
-        c3: 'BA==', // Base64 for [4] - internalId 2
-        c4: '', // Empty
-      });
-
-      queryStorage.setStationsData(mockStations);
-
-      expect(queryStorage.getItem('18786')).toBe('1');
-      expect(queryStorage.getItem('18787')).toBe('2');
-      expect(queryStorage.getItem('18788')).toBe('3');
-    });
-  });
 
 
 });

--- a/src/frontend/storage/query-storage.ts
+++ b/src/frontend/storage/query-storage.ts
@@ -1,19 +1,5 @@
 
 import { Storage } from './types';
-import { StationsGeoJSON } from '../types/geojson';
-
-function decode(buf: string | undefined): Uint8Array {
-    if (buf) {
-        try {
-            return new Uint8Array(atob(buf).split("").map((c) => {
-                return c.charCodeAt(0);
-            }));
-        } catch (e) {
-            console.log(e);
-        }
-    }
-    return new Uint8Array();
-}
 
 interface Queries {
     c1?: string;
@@ -28,64 +14,12 @@ export class QueryStorage implements Storage {
     c2: Set<string> = new Set();
     c3: Set<string> = new Set();
     c4: Set<string> = new Set();
-    private pendingQueries: Queries | null = null;
-    private stations: StationsGeoJSON | null = null;
+    queries: Queries = {};
 
-    setStationsData(stations: StationsGeoJSON): void {
-        this.stations = stations;
-
-        // Process pending queries if any
-        if (this.pendingQueries) {
-            this.processPendingQueries(this.pendingQueries);
-            this.pendingQueries = null;
+    constructor(queries?: Queries) {
+        if (queries) {
+            this.queries = queries;
         }
-    }
-
-    private getInternalIdMapping(): Map<string, string> {
-        const mapping = new Map<string, string>();
-        if (this.stations) {
-            this.stations.features.forEach(feature => {
-                mapping.set(feature.properties.internalId, feature.properties.stationId);
-            });
-        }
-        return mapping;
-    }
-
-    private processPendingQueries(queries: Queries): void {
-        // Convert internalId bitmaps back to stationId sets
-        const internalIdToStationId = this.getInternalIdMapping();
-
-        const processStyle = (encodedData: string | undefined): Set<string> => {
-            const resultSet = new Set<string>();
-            if (!encodedData) {
-                return resultSet;
-            }
-
-            const buf = decode(encodedData);
-
-            for (let i = 0; i < buf.length; i++) {
-                for (let bit = 0; bit < 8; bit++) {
-                    if (buf[i] & (1 << bit)) {
-                        const internalId = (i * 8 + bit).toString();
-                        const stationId = internalIdToStationId.get(internalId);
-                        if (stationId) {
-                            resultSet.add(stationId);
-                        }
-                    }
-                }
-            }
-            return resultSet;
-        };
-
-        this.c1 = processStyle(queries.c1);
-        this.c2 = processStyle(queries.c2);
-        this.c3 = processStyle(queries.c3);
-        this.c4 = processStyle(queries.c4);
-    }
-
-    loadFromQueries(queries: Queries): void {
-        // Store queries for later processing when stations data is available
-        this.pendingQueries = queries;
     }
 
     getItem(key: string): string | null {
@@ -125,5 +59,12 @@ export class QueryStorage implements Storage {
 
     listItems(): string[] {
         return [...this.c1, ...this.c2, ...this.c3, ...this.c4];
+    }
+
+    clearItems(): void {
+        this.c1.clear();
+        this.c2.clear();
+        this.c3.clear();
+        this.c4.clear();
     }
 }

--- a/src/frontend/storage/station-style-serializer.test.ts
+++ b/src/frontend/storage/station-style-serializer.test.ts
@@ -95,4 +95,179 @@ describe('StationStyleSerializer', () => {
       expect(queries.c4).toBe('');
     });
   });
+
+  describe('deserialize', () => {
+    it('should handle empty queries', () => {
+      const queryStorage = new QueryStorage({});
+      
+      StationStyleSerializer.deserialize(queryStorage, mockStations);
+      
+      expect(queryStorage.listItems()).toEqual([]);
+    });
+
+    it('should restore station styles from queries', () => {
+      const queryStorage = new QueryStorage({
+        c1: 'AQ==', // Base64 for [1] - represents internalId 0
+        c2: 'Ag==', // Base64 for [2] - represents internalId 1
+        c4: 'BA==', // Base64 for [4] - represents internalId 2
+      });
+      
+      StationStyleSerializer.deserialize(queryStorage, mockStations);
+      
+      expect(queryStorage.getItem('18786')).toBe('1'); // internalId 0 -> stationId 18786
+      expect(queryStorage.getItem('18787')).toBe('2'); // internalId 1 -> stationId 18787
+      expect(queryStorage.getItem('18788')).toBe('4'); // internalId 2 -> stationId 18788
+    });
+
+    it('should handle multiple stations with same style', () => {
+      const testStations = createMockStations(4);
+      const queryStorage = new QueryStorage({
+        c1: 'Bw==', // bits 0,1,2 set
+      });
+      
+      StationStyleSerializer.deserialize(queryStorage, testStations);
+      
+      expect(queryStorage.getItem('18786')).toBe('1'); // internalId 0
+      expect(queryStorage.getItem('18787')).toBe('1'); // internalId 1  
+      expect(queryStorage.getItem('18788')).toBe('1'); // internalId 2
+      expect(queryStorage.getItem('18789')).toBeNull(); // internalId 3 not set
+    });
+
+    it('should handle sparse data in large dataset', () => {
+      const testStations = createMockStations(100);
+      const queryStorage = new QueryStorage({
+        c1: 'AAIAAAAAAAAAAAAACA==', // bits 9 and 99 set
+        c2: 'AAAAAQ==', // bit 24 set
+        c3: 'AAAAAAAAAg==', // bit 49 set
+        c4: 'AAAAAAAAAAAABA==', // bit 74 set
+      });
+      
+      StationStyleSerializer.deserialize(queryStorage, testStations);
+      
+      expect(queryStorage.getItem('18795')).toBe('1');  // index 9
+      expect(queryStorage.getItem('18810')).toBe('2');  // index 24
+      expect(queryStorage.getItem('18835')).toBe('3');  // index 49
+      expect(queryStorage.getItem('18860')).toBe('4');  // index 74
+      expect(queryStorage.getItem('18885')).toBe('1');  // index 99
+      
+      // Verify only these 5 stations are set
+      expect(queryStorage.listItems()).toHaveLength(5);
+    });
+
+    it('should clear existing data before processing', () => {
+      const queryStorage = new QueryStorage({
+        c1: 'AQ==', // Only internalId 0
+      });
+      
+      // Pre-populate with different data
+      queryStorage.setItem('18787', '2');
+      queryStorage.setItem('18788', '3');
+      
+      StationStyleSerializer.deserialize(queryStorage, mockStations);
+      
+      // Should only have the data from queries, not the pre-populated data
+      expect(queryStorage.getItem('18786')).toBe('1');
+      expect(queryStorage.getItem('18787')).toBeNull();
+      expect(queryStorage.getItem('18788')).toBeNull();
+      expect(queryStorage.listItems()).toEqual(['18786']);
+    });
+  });
+
+  describe('round trip (serialize -> deserialize)', () => {
+    it('should preserve data through serialize/deserialize cycle', () => {
+      // Set up original data
+      const originalStorage = new QueryStorage();
+      originalStorage.setItem('18786', '1');
+      originalStorage.setItem('18787', '2');
+      originalStorage.setItem('18788', '4');
+      
+      // Serialize
+      const queries = StationStyleSerializer.serialize(originalStorage, mockStations);
+      
+      // Deserialize into new storage
+      const restoredStorage = new QueryStorage(queries);
+      StationStyleSerializer.deserialize(restoredStorage, mockStations);
+      
+      // Verify all data is preserved
+      expect(restoredStorage.getItem('18786')).toBe('1');
+      expect(restoredStorage.getItem('18787')).toBe('2');
+      expect(restoredStorage.getItem('18788')).toBe('4');
+      expect(restoredStorage.listItems()).toHaveLength(3);
+    });
+
+    it('should preserve empty state through round trip', () => {
+      const originalStorage = new QueryStorage();
+      
+      // Serialize empty storage
+      const queries = StationStyleSerializer.serialize(originalStorage, mockStations);
+      
+      // Deserialize
+      const restoredStorage = new QueryStorage(queries);
+      StationStyleSerializer.deserialize(restoredStorage, mockStations);
+      
+      expect(restoredStorage.listItems()).toEqual([]);
+    });
+
+    it('should preserve complex data patterns through round trip', () => {
+      const testStations = createMockStations(50);
+      const originalStorage = new QueryStorage();
+      
+      // Set up complex pattern
+      originalStorage.setItem('18786', '1'); // index 0
+      originalStorage.setItem('18787', '1'); // index 1
+      originalStorage.setItem('18790', '2'); // index 4
+      originalStorage.setItem('18800', '3'); // index 14
+      originalStorage.setItem('18820', '4'); // index 34
+      originalStorage.setItem('18835', '1'); // index 49
+      
+      // Serialize
+      const queries = StationStyleSerializer.serialize(originalStorage, testStations);
+      
+      // Deserialize
+      const restoredStorage = new QueryStorage(queries);
+      StationStyleSerializer.deserialize(restoredStorage, testStations);
+      
+      // Verify all data is preserved exactly
+      expect(restoredStorage.getItem('18786')).toBe('1');
+      expect(restoredStorage.getItem('18787')).toBe('1');
+      expect(restoredStorage.getItem('18790')).toBe('2');
+      expect(restoredStorage.getItem('18800')).toBe('3');
+      expect(restoredStorage.getItem('18820')).toBe('4');
+      expect(restoredStorage.getItem('18835')).toBe('1');
+      expect(restoredStorage.listItems()).toHaveLength(6);
+      
+      // Verify no extra data
+      expect(restoredStorage.getItem('18788')).toBeNull();
+      expect(restoredStorage.getItem('18799')).toBeNull();
+    });
+
+    it('should handle style transitions correctly in round trip', () => {
+      const originalStorage = new QueryStorage();
+      
+      // Test each style type
+      originalStorage.setItem('18786', '1');
+      originalStorage.setItem('18787', '2');
+      originalStorage.setItem('18788', '3');
+      // Note: not setting any style 4 to ensure it handles missing styles
+      
+      // First round trip
+      const queries1 = StationStyleSerializer.serialize(originalStorage, mockStations);
+      const restored1 = new QueryStorage(queries1);
+      StationStyleSerializer.deserialize(restored1, mockStations);
+      
+      // Second round trip (should be identical)
+      const queries2 = StationStyleSerializer.serialize(restored1, mockStations);
+      const restored2 = new QueryStorage(queries2);
+      StationStyleSerializer.deserialize(restored2, mockStations);
+      
+      // All round trips should be identical
+      expect(restored2.getItem('18786')).toBe('1');
+      expect(restored2.getItem('18787')).toBe('2');
+      expect(restored2.getItem('18788')).toBe('3');
+      expect(restored2.listItems()).toHaveLength(3);
+      
+      // Verify queries are identical across round trips
+      expect(queries1).toEqual(queries2);
+    });
+  });
 });

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -21,9 +21,10 @@ export class StyleManager {
 
     setStations(stations: StationsGeoJSON): void {
         this.stations = stations;
-        // Pass stations data to QueryStorage if it supports it
+        
+        // Process queries if this is a QueryStorage
         if (this.storage instanceof QueryStorage) {
-            this.storage.setStationsData(stations);
+            StationStyleSerializer.deserialize(this.storage, stations);
         }
     }
 
@@ -90,13 +91,13 @@ export class StyleManager {
         return StationStyleSerializer.serialize(this.storage, this.stations);
     }
 
+
 }
 
 export function getStyleManagerInstance(): StyleManager {
     const queries = queryString.parse(location.search);
     if (queries.mode === 'shared') {
-        const storage = new QueryStorage();
-        storage.loadFromQueries(queries);
+        const storage = new QueryStorage(queries);
         return new StyleManager(storage);
     }
     return new StyleManager(new LocalStorage());


### PR DESCRIPTION
- Add StationStyleSerializer.deserialize() method that takes QueryStorage and stations
- QueryStorage now stores queries in constructor and provides clearItems() method
- Integrate deserialize into StyleManager.setStations() for automatic query processing
- Remove redundant loadFromQueries/setStationsData methods from QueryStorage
- Add comprehensive round trip tests for serialize/deserialize symmetry
- Ensure data integrity through complete test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)