### PR TITLE
Refactor QueryStorage to use Map-based storage and ParsedQuery types

### DIFF
--- a/src/frontend/storage/local-storage.ts
+++ b/src/frontend/storage/local-storage.ts
@@ -23,4 +23,5 @@ export class LocalStorage implements Storage {
         });
         return items;
     }
+
 }

--- a/src/frontend/storage/query-storage.ts
+++ b/src/frontend/storage/query-storage.ts
@@ -1,70 +1,33 @@
 
 import { Storage } from './types';
-
-interface Queries {
-    c1?: string;
-    c2?: string;
-    c3?: string;
-    c4?: string;
-}
+import type { ParsedQuery } from 'query-string';
 
 export class QueryStorage implements Storage {
     mode: string = 'shared';
-    c1: Set<string> = new Set();
-    c2: Set<string> = new Set();
-    c3: Set<string> = new Set();
-    c4: Set<string> = new Set();
-    queries: Queries = {};
+    private storage: Map<string, string> = new Map();
+    queries: ParsedQuery<string> = {};
 
-    constructor(queries?: Queries) {
-        if (queries) {
-            this.queries = queries;
-        }
+    constructor(queries: ParsedQuery<string> = {}) {
+        this.queries = queries;
     }
 
     getItem(key: string): string | null {
-        // Work with stationId directly
-        if (this.c1.has(key)) {
-            return "1";
-        }
-        if (this.c2.has(key)) {
-            return "2";
-        }
-        if (this.c3.has(key)) {
-            return "3";
-        }
-        if (this.c4.has(key)) {
-            return "4";
-        }
-        return null;
+        return this.storage.get(key) || null;
     }
 
     setItem(key: string, value: string): void {
-        // Remove from all sets first
-        this.removeItem(key);
-
-        // Add to appropriate set
-        if (value === "1") this.c1.add(key);
-        else if (value === "2") this.c2.add(key);
-        else if (value === "3") this.c3.add(key);
-        else if (value === "4") this.c4.add(key);
+        this.storage.set(key, value);
     }
 
     removeItem(key: string): void {
-        this.c1.delete(key);
-        this.c2.delete(key);
-        this.c3.delete(key);
-        this.c4.delete(key);
+        this.storage.delete(key);
     }
 
     listItems(): string[] {
-        return [...this.c1, ...this.c2, ...this.c3, ...this.c4];
+        return Array.from(this.storage.keys());
     }
 
     clearItems(): void {
-        this.c1.clear();
-        this.c2.clear();
-        this.c3.clear();
-        this.c4.clear();
+        this.storage.clear();
     }
 }

--- a/src/frontend/storage/station-style-serializer.ts
+++ b/src/frontend/storage/station-style-serializer.ts
@@ -19,16 +19,9 @@ function decode(buf: string | undefined): Uint8Array {
     return new Uint8Array();
 }
 
-interface Queries {
-    c1?: string;
-    c2?: string;
-    c3?: string;
-    c4?: string;
-}
-
 export class StationStyleSerializer {
-    static serialize(storage: Storage, stations: StationsGeoJSON): Queries {
-        const queries: Queries = {};
+    static serialize(storage: Storage, stations: StationsGeoJSON): Record<string, string> {
+        const queries: Record<string, string> = {};
 
         // Create station ID to internal ID mapping
         const stationIdToInternalId = new Map<string, string>();
@@ -82,7 +75,11 @@ export class StationStyleSerializer {
             internalIdToStationId.set(feature.properties.internalId, feature.properties.stationId);
         });
 
-        const processStyle = (encodedData: string | undefined, styleId: string): void => {
+        const processStyle = (encodedData: string | null | Array<string | null> | undefined, styleId: string): void => {
+            // Only process if it's a string
+            if (typeof encodedData !== 'string') {
+                return;
+            }
             const buf = decode(encodedData);
 
             for (let i = 0; i < buf.length; i++) {


### PR DESCRIPTION
- Replace c1-c4 Set properties with private Map for cleaner KVS interface
- Update constructor to accept ParsedQuery<string> directly from query-string library
- Remove duplicate Queries interface from StationStyleSerializer
- Simplify type handling by keeping ParsedQuery type throughout the pipeline
- Improve encapsulation by making storage implementation private

🤖 Generated with [Claude Code](https://claude.ai/code)