### PR TITLE
Clean up invalid station entries from storage on setStations

### DIFF
--- a/src/frontend/style-manager.test.ts
+++ b/src/frontend/style-manager.test.ts
@@ -206,6 +206,51 @@ describe('StyleManager', () => {
         });
     });
 
+    describe('setStations', () => {
+        beforeEach(() => {
+            localStorage.clear();
+        });
+
+        it('should remove stored entries for stations not present in the GeoJSON (LocalStorage)', () => {
+            const storage = new LocalStorage();
+            storage.setItem('18786', '1');  // exists in mock stations
+            storage.setItem('99999', '2');  // does not exist
+            const styleManager = new StyleManager(storage);
+
+            const mockStations = createMockStations(3);
+            styleManager.setStations(mockStations);
+
+            expect(storage.getItem('18786')).toBe('1');
+            expect(storage.getItem('99999')).toBeNull();
+        });
+
+        it('should keep all stored entries when every stationId exists in the GeoJSON', () => {
+            const storage = new LocalStorage();
+            storage.setItem('18786', '1');
+            storage.setItem('18787', '2');
+            const styleManager = new StyleManager(storage);
+
+            const mockStations = createMockStations(3);
+            styleManager.setStations(mockStations);
+
+            expect(storage.getItem('18786')).toBe('1');
+            expect(storage.getItem('18787')).toBe('2');
+        });
+
+        it('should reflect cleanup in countByStyle (LocalStorage)', () => {
+            const storage = new LocalStorage();
+            storage.setItem('18786', '1');  // valid
+            storage.setItem('99999', '2');  // invalid (removed station)
+            const styleManager = new StyleManager(storage);
+
+            const mockStations = createMockStations(3);
+            styleManager.setStations(mockStations);
+
+            const counts = styleManager.countByStyle(3);
+            expect(counts).toEqual({ 0: 2, 1: 1, 2: 0, 3: 0, 4: 0 });
+        });
+    });
+
     describe('toQuery', () => {
         it('should generate empty queries when storage is empty', () => {
             const queryStorage = new QueryStorage();

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -21,11 +21,19 @@ export class StyleManager {
 
     setStations(stations: StationsGeoJSON): void {
         this.stations = stations;
-        
+
         // Process queries if this is a QueryStorage
         if (this.storage instanceof QueryStorage) {
             StationStyleSerializer.deserialize(this.storage, stations);
         }
+
+        // Remove stored entries for stations that no longer exist in the GeoJSON
+        const validStationIds = new Set(stations.features.map(feature => feature.properties.stationId));
+        this.storage.listItems().forEach(stationId => {
+            if (!validStationIds.has(stationId)) {
+                this.storage.removeItem(stationId);
+            }
+        });
     }
 
     private getStationId(station: RoadStation | string): string {


### PR DESCRIPTION
## Summary
This PR adds automatic cleanup of invalid station entries from storage when `setStations()` is called. When the GeoJSON is updated with a new set of stations, any stored entries for stations that no longer exist are now removed.

## Key Changes
- **Storage cleanup logic**: Added validation in `StyleManager.setStations()` to remove stored entries for stations not present in the updated GeoJSON
- **Implementation**: Creates a Set of valid station IDs from the GeoJSON features and removes any stored items that don't match
- **Test coverage**: Added comprehensive test suite for `setStations()` with three test cases:
  - Verifies removal of entries for non-existent stations while keeping valid ones
  - Confirms all entries are preserved when all station IDs exist in the GeoJSON
  - Validates that `countByStyle()` correctly reflects the cleanup

## Notable Details
- The cleanup runs for all storage types (LocalStorage and QueryStorage)
- Uses `storage.listItems()` to iterate over stored station IDs and `storage.removeItem()` for cleanup
- Maintains existing QueryStorage deserialization logic
- Minor formatting fix: removed trailing whitespace in `setStations()`

https://claude.ai/code/session_014GxFEP9mCDUBZ6D1tSWb9M