### PR TITLE
Refactor auto-merge workflow to use label-based triggering

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,39 +1,12 @@
-name: Auto-merge
-
+name: Auto merge Pull Requests
 on:
   pull_request:
+    types: [labeled]
 
 jobs:
-  dependabot:
+  auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.repository == 'tk0miya/roadside_station_maps'
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
-          private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
-
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-
-      - name: Auto-approve and merge
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: |
-          gh pr edit "$PR_URL" --add-label "auto-merge"
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-  station_data:
-    runs-on: ubuntu-latest
-    if: github.actor == 'roadside-station-updater[bot]' && github.repository == 'tk0miya/roadside_station_maps'
+    if: github.event.label.name == 'auto-merge'
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -44,7 +17,6 @@ jobs:
 
       - name: Approve a PR
         run: |
-          gh pr edit "$PR_URL" --add-label "auto-merge"
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,0 +1,29 @@
+name: Add auto-merge label to Dependabot PRs
+on: pull_request
+
+jobs:
+  add-auto-merge-label:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Add auto-merge label
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr edit "$PR_URL" --add-label "auto-merge"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-station-data.yml
+++ b/.github/workflows/update-station-data.yml
@@ -43,5 +43,6 @@ jobs:
         commit-message: "Update station data"
         branch: bot/update-station-data
         title: "Update station data"
+        labels: auto-merge
         token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
Refactored the auto-merge GitHub Actions workflow to use a label-based triggering mechanism instead of actor-based conditions. This change separates concerns by moving Dependabot-specific logic into a dedicated workflow.

## Key Changes
- **Consolidated auto-merge job**: Replaced separate `dependabot` and `station_data` jobs with a single `auto-merge` job that triggers on the `auto-merge` label
- **New Dependabot workflow**: Created `.github/workflows/dependabot-auto-label.yml` to automatically add the `auto-merge` label to Dependabot PRs that meet version update criteria (minor/patch)
- **Simplified trigger logic**: Changed from actor-based conditions (`github.actor == 'dependabot[bot]'`) to label-based conditions (`github.event.label.name == 'auto-merge'`)
- **Updated station data workflow**: Added `labels: auto-merge` to the pull request creation in `update-station-data.yml` to automatically trigger auto-merge for station data updates
- **Removed redundant steps**: Eliminated the `gh pr edit` command that added the label from the main auto-merge workflow since labeling is now handled upstream

## Implementation Details
- The new `dependabot-auto-label.yml` workflow checks Dependabot metadata and conditionally adds the `auto-merge` label based on update type
- The main `auto-merge.yml` workflow now listens for the `labeled` event type, making it more explicit and easier to understand
- Both workflows use the same GitHub App token for authentication
- The station data workflow now automatically labels its PRs for auto-merge, eliminating manual intervention

https://claude.ai/code/session_017PyCTCwcX1zWJdmPeZUMdr