### PR TITLE
Change StationCounter control position from TOP_RIGHT to RIGHT_TOP

### DIFF
--- a/src/frontend/components/StationCounter.test.tsx
+++ b/src/frontend/components/StationCounter.test.tsx
@@ -32,7 +32,7 @@ describe('StationCounter', () => {
 
         expect(container.firstChild).toBeNull(); // Component renders null
         expect(mockStyleManager.countByStyle).toHaveBeenCalledWith(100);
-        expect(mockMap.controls[3].push).toHaveBeenCalledTimes(1);
+        expect(mockMap.controls[7].push).toHaveBeenCalledTimes(1);
     });
 
     it('should not render when map is null', () => {

--- a/src/frontend/components/StationCounter.tsx
+++ b/src/frontend/components/StationCounter.tsx
@@ -24,7 +24,7 @@ export function StationCounter({ styleManager, stations, styleVersion: _styleVer
         contentRootRef.current = createRoot(contentElementRef.current);
 
         // Add to map controls
-        map.controls[google.maps.ControlPosition.TOP_RIGHT].push(contentElementRef.current);
+        map.controls[google.maps.ControlPosition.RIGHT_TOP].push(contentElementRef.current);
     }, [map]);
 
     useEffect(() => {

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -6,6 +6,7 @@ export const createMockMap = () => {
     const topLeftControls: HTMLElement[] = [];
     const topCenterControls: HTMLElement[] = [];
     const topRightControls: HTMLElement[] = [];
+    const rightTopControls: HTMLElement[] = [];
 
     const controls = {
         [1]: {  // TOP_LEFT
@@ -22,6 +23,11 @@ export const createMockMap = () => {
             push: vi.fn((element: HTMLElement) => topRightControls.push(element)),
             removeAt: vi.fn((index: number) => topRightControls.splice(index, 1)),
             getArray: vi.fn(() => topRightControls),
+        },
+        [7]: {  // RIGHT_TOP
+            push: vi.fn((element: HTMLElement) => rightTopControls.push(element)),
+            removeAt: vi.fn((index: number) => rightTopControls.splice(index, 1)),
+            getArray: vi.fn(() => rightTopControls),
         },
     };
 
@@ -106,7 +112,8 @@ export const setupGoogleMapsMock = () => {
             ControlPosition: {
                 TOP_LEFT: 1,
                 TOP_CENTER: 2,
-                TOP_RIGHT: 3
+                TOP_RIGHT: 3,
+                RIGHT_TOP: 7
             }
         }
     };


### PR DESCRIPTION
## Summary
Updated the StationCounter component to use the `RIGHT_TOP` control position instead of `TOP_RIGHT` when adding the counter to the Google Map controls.

## Key Changes
- Modified `StationCounter.tsx` to use `google.maps.ControlPosition.RIGHT_TOP` instead of `TOP_RIGHT` when pushing the counter element to map controls
- Added support for the `RIGHT_TOP` control position (value: 7) in the test utilities mock map setup
- Updated the corresponding test assertion to verify the counter is added to the correct control position

## Implementation Details
- Added `rightTopControls` array to the mock map in `test-utils.ts` to support the new control position
- Extended the `ControlPosition` enum in the Google Maps mock to include `RIGHT_TOP: 7`
- Updated `StationCounter.test.tsx` to assert that the push method is called on `controls[7]` (RIGHT_TOP) instead of `controls[3]` (TOP_RIGHT)

https://claude.ai/code/session_013F9a2rXMH3QFpMsbGKazac