### PR TITLE
Replace LocalStorage with MemoryStorage for guest mode

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -53,7 +53,7 @@ export function RoadStationMap() {
     }, []);
 
     // Build the StyleManager whenever the auth state changes. RemoteStorage hydrates
-    // asynchronously when signed in; LocalStorage / MemoryStorage resolve immediately.
+    // asynchronously when signed in; MemoryStorage resolves immediately.
     useEffect(() => {
         let cancelled = false;
         setStyleManager((previous) => {

--- a/src/frontend/style-manager.test.ts
+++ b/src/frontend/style-manager.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StyleManager, createStyleManager } from './style-manager';
 import { MemoryStorage } from './storage/memory-storage';
-import { LocalStorage } from './storage/local-storage';
 import { RemoteStorage } from './storage/remote-storage';
 import { createMockStation, createMockStations } from '../test-utils/test-utils';
 import type { AuthState } from '@shared/auth-types';
@@ -209,12 +208,8 @@ describe('StyleManager', () => {
     });
 
     describe('setStations', () => {
-        beforeEach(() => {
-            localStorage.clear();
-        });
-
-        it('should remove stored entries for stations not present in the GeoJSON (LocalStorage)', () => {
-            const storage = new LocalStorage();
+        it('should remove stored entries for stations not present in the GeoJSON', () => {
+            const storage = new MemoryStorage();
             storage.setItem('18786', '1');  // exists in mock stations
             storage.setItem('99999', '2');  // does not exist
             const styleManager = new StyleManager(storage);
@@ -227,7 +222,7 @@ describe('StyleManager', () => {
         });
 
         it('should keep all stored entries when every stationId exists in the GeoJSON', () => {
-            const storage = new LocalStorage();
+            const storage = new MemoryStorage();
             storage.setItem('18786', '1');
             storage.setItem('18787', '2');
             const styleManager = new StyleManager(storage);
@@ -239,8 +234,8 @@ describe('StyleManager', () => {
             expect(storage.getItem('18787')).toBe('2');
         });
 
-        it('should reflect cleanup in countByStyle (LocalStorage)', () => {
-            const storage = new LocalStorage();
+        it('should reflect cleanup in countByStyle', () => {
+            const storage = new MemoryStorage();
             storage.setItem('18786', '1');  // valid
             storage.setItem('99999', '2');  // invalid (removed station)
             const styleManager = new StyleManager(storage);
@@ -273,12 +268,13 @@ describe('createStyleManager', () => {
         Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
     });
 
-    it('returns a LocalStorage-backed StyleManager for guests', async () => {
+    it('returns an empty MemoryStorage-backed StyleManager for guests', async () => {
         const manager = await createStyleManager({
             authState: guestAuth,
             getIdToken: () => null,
         });
-        expect(manager.storage).toBeInstanceOf(LocalStorage);
+        expect(manager.storage).toBeInstanceOf(MemoryStorage);
+        expect(manager.storage.listItems()).toEqual([]);
     });
 
     it('returns a MemoryStorage-backed StyleManager hydrated from the shares API when share is set', async () => {

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -1,6 +1,5 @@
 import queryString from 'query-string';
 import { API_BASE_URL } from './config';
-import { LocalStorage } from './storage/local-storage';
 import { MemoryStorage } from './storage/memory-storage';
 import { RemoteStorage } from './storage/remote-storage';
 import { SharesApiClient } from './storage/shares-api-client';
@@ -100,7 +99,7 @@ export interface CreateStyleManagerOptions {
  *
  * - `?share=<id>` -> MemoryStorage hydrated from the shares API
  * - signed-in user -> RemoteStorage backed by the Workers + D1 API
- * - otherwise      -> LocalStorage (guest mode, identical to legacy behavior)
+ * - otherwise      -> MemoryStorage (guest mode, data lives only in memory)
  */
 export async function createStyleManager(options: CreateStyleManagerOptions): Promise<StyleManager> {
     const queries = queryString.parse(location.search);
@@ -132,5 +131,5 @@ export async function createStyleManager(options: CreateStyleManagerOptions): Pr
         return new StyleManager(storage);
     }
 
-    return new StyleManager(new LocalStorage());
+    return new StyleManager(new MemoryStorage());
 }


### PR DESCRIPTION
## Summary
This PR replaces `LocalStorage` with `MemoryStorage` for guest users (non-authenticated, non-shared sessions). Guest users will now have their style preferences stored only in memory and lost on page refresh, rather than persisted to browser localStorage.

## Key Changes
- Removed `LocalStorage` import and usage from `style-manager.ts` and `style-manager.test.ts`
- Updated `createStyleManager()` to return a `MemoryStorage`-backed `StyleManager` for guest users instead of `LocalStorage`
- Removed `beforeEach` hook that cleared localStorage in tests, as it's no longer needed
- Updated all test cases in the `setStations` suite to use `MemoryStorage` instead of `LocalStorage`
- Updated test expectations and descriptions to reflect the new guest mode behavior
- Updated code comments to clarify that guest mode now uses in-memory storage only

## Implementation Details
- Guest users (those without authentication or share tokens) will now have a clean `MemoryStorage` instance with no persisted data
- The storage hierarchy remains: share tokens → RemoteStorage, signed-in users → RemoteStorage, guests → MemoryStorage
- All existing functionality is preserved; only the persistence mechanism for guests has changed
- Tests now verify that guest mode returns an empty `MemoryStorage` instance

https://claude.ai/code/session_015Q8RyTPHzEXt49HUuUqiFu