### PR TITLE
Preserve /html/ URL path when deploying to Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,16 @@ jobs:
       - name: Build bundle
         run: npm run build
 
+      - name: Stage Pages content
+        run: |
+          mkdir -p _site
+          cp -r html _site/
+          cp -r data _site/
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: html
+          path: _site
 
   deploy:
     needs: build


### PR DESCRIPTION
The frontend fetches data via the relative path '../data/stations.geojson', which only resolves correctly when the page is served from /html/. Stage both html/ and data/ under a _site/ root before uploading the Pages artifact so the deployed layout matches the previous repo-root structure.

https://claude.ai/code/session_012uNjenNWBMVwiAxcpNiNbT