### PR TITLE
Remove fetchImpl dependency injection from API clients

### DIFF
--- a/src/frontend/storage/shares-api-client.test.ts
+++ b/src/frontend/storage/shares-api-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { SharesApiClient, SharesApiError } from './shares-api-client';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -9,16 +9,19 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('SharesApiClient', () => {
-    let fetchMock: ReturnType<typeof vi.fn>;
+    let fetchMock: MockInstance<typeof fetch>;
     let client: SharesApiClient;
 
     beforeEach(() => {
-        fetchMock = vi.fn();
+        fetchMock = vi.spyOn(globalThis, 'fetch');
         client = new SharesApiClient({
             baseUrl: 'https://api.example.com/',
             getIdToken: () => 'test-token',
-            fetchImpl: fetchMock as unknown as typeof fetch,
         });
+    });
+
+    afterEach(() => {
+        fetchMock.mockRestore();
     });
 
     it('POSTs /api/shares with the bearer token and returns the share id', async () => {
@@ -40,7 +43,6 @@ describe('SharesApiClient', () => {
         const noTokenClient = new SharesApiClient({
             baseUrl: 'https://api.example.com',
             getIdToken: () => null,
-            fetchImpl: fetchMock as unknown as typeof fetch,
         });
 
         await expect(noTokenClient.create()).rejects.toBeInstanceOf(SharesApiError);

--- a/src/frontend/storage/shares-api-client.ts
+++ b/src/frontend/storage/shares-api-client.ts
@@ -3,7 +3,6 @@ import type { CreateShareResponse, GetShareResponse, VisitRecord } from '@shared
 export interface SharesApiClientOptions {
     baseUrl: string;
     getIdToken: () => string | null;
-    fetchImpl?: typeof fetch;
 }
 
 export class SharesApiError extends Error {
@@ -19,12 +18,10 @@ export class SharesApiError extends Error {
 export class SharesApiClient {
     private readonly baseUrl: string;
     private readonly getIdToken: () => string | null;
-    private readonly fetchImpl: typeof fetch;
 
     constructor(options: SharesApiClientOptions) {
         this.baseUrl = options.baseUrl.replace(/\/$/, '');
         this.getIdToken = options.getIdToken;
-        this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
     }
 
     async create(): Promise<string> {
@@ -33,7 +30,7 @@ export class SharesApiClient {
             throw new SharesApiError('Missing ID token; user must be signed in');
         }
 
-        const response = await this.fetchImpl(`${this.baseUrl}/api/shares`, {
+        const response = await fetch(`${this.baseUrl}/api/shares`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -46,10 +43,9 @@ export class SharesApiClient {
     }
 
     async get(shareId: string): Promise<VisitRecord[]> {
-        const response = await this.fetchImpl(
-            `${this.baseUrl}/shares/${encodeURIComponent(shareId)}`,
-            { method: 'GET' }
-        );
+        const response = await fetch(`${this.baseUrl}/shares/${encodeURIComponent(shareId)}`, {
+            method: 'GET',
+        });
 
         if (!response.ok) {
             throw new SharesApiError(await readErrorMessage(response), response.status);

--- a/src/frontend/storage/visits-api-client.test.ts
+++ b/src/frontend/storage/visits-api-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { VisitsApiClient, VisitsApiError } from './visits-api-client';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -13,16 +13,19 @@ function emptyResponse(status = 204): Response {
 }
 
 describe('VisitsApiClient', () => {
-    let fetchMock: ReturnType<typeof vi.fn>;
+    let fetchMock: MockInstance<typeof fetch>;
     let client: VisitsApiClient;
 
     beforeEach(() => {
-        fetchMock = vi.fn();
+        fetchMock = vi.spyOn(globalThis, 'fetch');
         client = new VisitsApiClient({
             baseUrl: 'https://api.example.com/',
             getIdToken: () => 'test-token',
-            fetchImpl: fetchMock as unknown as typeof fetch,
         });
+    });
+
+    afterEach(() => {
+        fetchMock.mockRestore();
     });
 
     it('GETs /api/visits with the bearer token', async () => {
@@ -80,7 +83,6 @@ describe('VisitsApiClient', () => {
         const noTokenClient = new VisitsApiClient({
             baseUrl: 'https://api.example.com',
             getIdToken: () => null,
-            fetchImpl: fetchMock as unknown as typeof fetch,
         });
 
         await expect(noTokenClient.list()).rejects.toBeInstanceOf(VisitsApiError);

--- a/src/frontend/storage/visits-api-client.ts
+++ b/src/frontend/storage/visits-api-client.ts
@@ -3,7 +3,6 @@ import type { ListVisitsResponse, PutVisitRequest, VisitRecord } from '@shared/a
 export interface VisitsApiClientOptions {
     baseUrl: string;
     getIdToken: () => string | null;
-    fetchImpl?: typeof fetch;
 }
 
 export class VisitsApiError extends Error {
@@ -19,12 +18,10 @@ export class VisitsApiError extends Error {
 export class VisitsApiClient {
     private readonly baseUrl: string;
     private readonly getIdToken: () => string | null;
-    private readonly fetchImpl: typeof fetch;
 
     constructor(options: VisitsApiClientOptions) {
         this.baseUrl = options.baseUrl.replace(/\/$/, '');
         this.getIdToken = options.getIdToken;
-        this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
     }
 
     async list(): Promise<VisitRecord[]> {
@@ -52,7 +49,7 @@ export class VisitsApiClient {
             throw new VisitsApiError('Missing ID token; user must be signed in');
         }
 
-        const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        const response = await fetch(`${this.baseUrl}${path}`, {
             ...init,
             headers: {
                 ...(init.headers ?? {}),


### PR DESCRIPTION
## Summary
Refactored the SharesApiClient and VisitsApiClient to use the global `fetch` function directly instead of accepting it as an injectable dependency. Updated tests to use `vi.spyOn()` for mocking the global fetch function rather than passing a mock implementation.

## Key Changes
- Removed `fetchImpl` optional parameter from `SharesApiClientOptions` and `VisitsApiClientOptions` interfaces
- Removed `fetchImpl` private field from both API client classes
- Replaced all `this.fetchImpl()` calls with direct `fetch()` calls
- Updated test setup to use `vi.spyOn(globalThis, 'fetch')` instead of `vi.fn()` for mocking
- Added `afterEach()` hooks to properly restore the fetch mock after each test
- Updated mock type annotations from `ReturnType<typeof vi.fn>` to `MockInstance<typeof fetch>` for better type safety
- Removed `fetchImpl` mock parameter from client instantiation in tests

## Implementation Details
The change simplifies the API client architecture by removing the unnecessary abstraction layer. Since tests can now mock the global `fetch` function directly using Vitest's `spyOn`, there's no need to support dependency injection of the fetch implementation. This reduces boilerplate and makes the code more straightforward while maintaining full test coverage and mockability.

https://claude.ai/code/session_01PFqRePAzPQ3oAEb9tf6jGH