### PR TITLE
Consolidate config exports to single config file

### DIFF
--- a/src/frontend/app.tsx
+++ b/src/frontend/app.tsx
@@ -1,6 +1,6 @@
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { createRoot } from 'react-dom/client';
-import { GOOGLE_CLIENT_ID } from './auth/config';
+import { GOOGLE_CLIENT_ID } from './config';
 import { RoadStationMap } from './components/RoadStationMap';
 
 const container = document.getElementById('map-canvas');

--- a/src/frontend/auth/auth-manager.ts
+++ b/src/frontend/auth/auth-manager.ts
@@ -1,6 +1,6 @@
 import { decodeJwt } from 'jose';
 import type { AuthState, AuthUser } from '@shared/auth-types';
-import { GOOGLE_CLIENT_ID } from './config';
+import { GOOGLE_CLIENT_ID } from '../config';
 
 export const ID_TOKEN_STORAGE_KEY = 'auth:idToken';
 

--- a/src/frontend/auth/config.ts
+++ b/src/frontend/auth/config.ts
@@ -1,4 +1,0 @@
-// Public OAuth client ID for Google Identity Services. The security gate is the
-// Authorized JavaScript origin configured in the Google Cloud Console, not the
-// secrecy of this value.
-export const GOOGLE_CLIENT_ID = '740963820239-n5t81ueg3b27mtcs229fk62na8bfjvva.apps.googleusercontent.com';

--- a/src/frontend/components/LoginButton.test.tsx
+++ b/src/frontend/components/LoginButton.test.tsx
@@ -8,7 +8,7 @@ import {
     ID_TOKEN_STORAGE_KEY,
     resetAuthManagerInstanceForTests,
 } from '../auth/auth-manager';
-import { GOOGLE_CLIENT_ID } from '../auth/config';
+import { GOOGLE_CLIENT_ID } from '../config';
 import { createMockMap, setupGoogleMapsMock } from '../../test-utils/test-utils';
 
 let lastGoogleLoginProps: { onSuccess?: (response: { credential?: string }) => void } | null = null;

--- a/src/frontend/config.ts
+++ b/src/frontend/config.ts
@@ -14,3 +14,8 @@ const isDevelopmentHost =
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
 
 export const API_BASE_URL: string = isDevelopmentHost ? DEVELOPMENT_API : PRODUCTION_API;
+
+// Public OAuth client ID for Google Identity Services. The security gate is the
+// Authorized JavaScript origin configured in the Google Cloud Console, not the
+// secrecy of this value.
+export const GOOGLE_CLIENT_ID = '740963820239-n5t81ueg3b27mtcs229fk62na8bfjvva.apps.googleusercontent.com';


### PR DESCRIPTION
## Summary
Consolidated the Google OAuth client ID configuration from a separate auth-specific config file into the main frontend config file, reducing file fragmentation and improving configuration organization.

## Key Changes
- Moved `GOOGLE_CLIENT_ID` export from `src/frontend/auth/config.ts` to `src/frontend/config.ts`
- Removed the now-empty `src/frontend/auth/config.ts` file
- Updated all import statements across the codebase to reference the new location:
  - `src/frontend/app.tsx`
  - `src/frontend/auth/auth-manager.ts`
  - `src/frontend/components/LoginButton.test.tsx`

## Implementation Details
- The `GOOGLE_CLIENT_ID` constant and its associated comment explaining that it's a public value secured by authorized JavaScript origins remain unchanged
- All imports were updated to use relative paths appropriate to their new location (`./config` or `../config`)
- No functional changes to the authentication logic or configuration values

https://claude.ai/code/session_01RUNrptMyzw3RjXsgpvzBaV