### PR TITLE
Add silent re-authentication via Google One Tap

### DIFF
--- a/src/frontend/app.tsx
+++ b/src/frontend/app.tsx
@@ -1,5 +1,6 @@
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { createRoot } from 'react-dom/client';
+import { SilentSignIn } from './auth/SilentSignIn';
 import { GOOGLE_CLIENT_ID } from './config';
 import { RoadStationMap } from './components/RoadStationMap';
 
@@ -8,6 +9,7 @@ if (container) {
     const root = createRoot(container);
     root.render(
         <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+            <SilentSignIn />
             <RoadStationMap />
         </GoogleOAuthProvider>
     );

--- a/src/frontend/auth/SilentSignIn.test.tsx
+++ b/src/frontend/auth/SilentSignIn.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getAuthManagerInstance,
+    ID_TOKEN_STORAGE_KEY,
+    resetAuthManagerInstanceForTests,
+} from './auth-manager';
+import { GOOGLE_CLIENT_ID } from '../config';
+
+interface OneTapOptions {
+    onSuccess: (response: { credential?: string }) => void;
+    auto_select?: boolean;
+    disabled?: boolean;
+}
+
+let lastOneTapOptions: OneTapOptions | null = null;
+
+vi.mock('@react-oauth/google', () => ({
+    useGoogleOneTapLogin: (options: OneTapOptions) => {
+        lastOneTapOptions = options;
+    },
+}));
+
+import { SilentSignIn } from './SilentSignIn';
+
+function base64UrlEncode(input: string): string {
+    return Buffer.from(input, 'utf8').toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function buildIdToken(payload: Record<string, unknown>): string {
+    const header = base64UrlEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+    const body = base64UrlEncode(JSON.stringify(payload));
+    return `${header}.${body}.sig`;
+}
+
+function validToken(overrides: Record<string, unknown> = {}): string {
+    return buildIdToken({
+        sub: 'user-1',
+        iss: 'https://accounts.google.com',
+        aud: GOOGLE_CLIENT_ID,
+        exp: 9999999999,
+        ...overrides,
+    });
+}
+
+describe('SilentSignIn', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        resetAuthManagerInstanceForTests();
+        lastOneTapOptions = null;
+    });
+
+    it('is disabled for first-time visitors with no prior session', () => {
+        render(<SilentSignIn />);
+
+        expect(lastOneTapOptions?.disabled).toBe(true);
+        expect(lastOneTapOptions?.auto_select).toBe(true);
+    });
+
+    it('is disabled while the user is already signed in', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken());
+
+        render(<SilentSignIn />);
+
+        expect(lastOneTapOptions?.disabled).toBe(true);
+    });
+
+    it('is enabled when an expired token is found in storage', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        render(<SilentSignIn />);
+
+        expect(lastOneTapOptions?.disabled).toBe(false);
+    });
+
+    it('forwards a successfully returned credential to AuthManager.handleCredential', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        render(<SilentSignIn />);
+
+        const handleCredential = vi.spyOn(getAuthManagerInstance(), 'handleCredential');
+        const newToken = validToken({ sub: 'user-2' });
+
+        lastOneTapOptions?.onSuccess({ credential: newToken });
+
+        expect(handleCredential).toHaveBeenCalledWith(newToken);
+    });
+});

--- a/src/frontend/auth/SilentSignIn.tsx
+++ b/src/frontend/auth/SilentSignIn.tsx
@@ -1,0 +1,25 @@
+import { useGoogleOneTapLogin } from '@react-oauth/google';
+import { getAuthManagerInstance } from './auth-manager';
+import { useAuth } from './use-auth';
+
+// Attempts a silent re-authentication via Google One Tap with auto_select.
+// Only enabled when the user previously had a session (token in storage at
+// startup, or a successful login earlier in this session) so that first-time
+// visitors are not prompted unexpectedly.
+export function SilentSignIn() {
+    const state = useAuth();
+    const manager = getAuthManagerInstance();
+    const shouldAttempt = !state.user && manager.hadPreviousSession;
+
+    useGoogleOneTapLogin({
+        onSuccess: (response) => {
+            if (response.credential) {
+                manager.handleCredential(response.credential);
+            }
+        },
+        auto_select: true,
+        disabled: !shouldAttempt,
+    });
+
+    return null;
+}

--- a/src/frontend/auth/auth-manager.test.ts
+++ b/src/frontend/auth/auth-manager.test.ts
@@ -144,6 +144,38 @@ describe('AuthManager', () => {
         expect(localStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
     });
 
+    it('reports no previous session for empty storage', () => {
+        const manager = new AuthManager(CLIENT_ID);
+
+        expect(manager.hadPreviousSession).toBe(false);
+    });
+
+    it('reports a previous session when a valid token is rehydrated', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken());
+
+        const manager = new AuthManager(CLIENT_ID);
+
+        expect(manager.hadPreviousSession).toBe(true);
+    });
+
+    it('reports a previous session when an expired token is found in storage', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const manager = new AuthManager(CLIENT_ID);
+
+        expect(manager.getState().user).toBeNull();
+        expect(manager.hadPreviousSession).toBe(true);
+    });
+
+    it('reports a previous session after a successful handleCredential call', () => {
+        const manager = new AuthManager(CLIENT_ID);
+        expect(manager.hadPreviousSession).toBe(false);
+
+        manager.handleCredential(validToken());
+
+        expect(manager.hadPreviousSession).toBe(true);
+    });
+
     it('allows unsubscribing listeners', () => {
         const manager = new AuthManager(CLIENT_ID);
 

--- a/src/frontend/auth/auth-manager.ts
+++ b/src/frontend/auth/auth-manager.ts
@@ -11,6 +11,10 @@ type Listener = (state: AuthState) => void;
 export class AuthManager {
     private state: AuthState = { user: null, idToken: null };
     private listeners: Set<Listener> = new Set();
+    // True if the user was authenticated in this session or had a (possibly
+    // expired) token in storage at startup. Used to gate silent re-login
+    // attempts so brand-new visitors are not prompted unexpectedly.
+    hadPreviousSession = false;
 
     constructor(private readonly clientId: string) {
         this.rehydrateFromStorage();
@@ -20,6 +24,7 @@ export class AuthManager {
         const user = this.verifyIdToken(idToken);
         if (!user) return;
         localStorage.setItem(ID_TOKEN_STORAGE_KEY, idToken);
+        this.hadPreviousSession = true;
         this.setState({ user, idToken });
     }
 
@@ -37,6 +42,8 @@ export class AuthManager {
     private rehydrateFromStorage(): void {
         const stored = localStorage.getItem(ID_TOKEN_STORAGE_KEY);
         if (!stored) return;
+
+        this.hadPreviousSession = true;
 
         const user = this.verifyIdToken(stored);
         if (user) {


### PR DESCRIPTION
## Summary
Implements silent re-authentication for users with previous sessions using Google One Tap's auto-select feature. This allows users who were previously logged in to be seamlessly re-authenticated without explicit action, while avoiding unexpected prompts for first-time visitors.

## Key Changes
- **New `SilentSignIn` component**: Renders Google One Tap with auto-select enabled only when appropriate (user not currently signed in but has a previous session)
- **`hadPreviousSession()` method in AuthManager**: Tracks whether a user had a valid or expired token at startup, or successfully authenticated during the current session
- **Session tracking**: AuthManager now maintains a flag that is set when:
  - A token is rehydrated from storage during initialization (even if expired)
  - A credential is successfully handled via `handleCredential()`
- **Integration in app root**: `SilentSignIn` component mounted at the app root within `GoogleOAuthProvider` to enable silent re-auth attempts early in the app lifecycle

## Implementation Details
- The `disabled` prop on `useGoogleOneTapLogin` is set to `true` for first-time visitors (no previous session) and users already signed in, preventing unexpected prompts
- `auto_select` is always enabled to allow Google to automatically select a previously used account
- Expired tokens in storage are recognized as evidence of a previous session, enabling re-authentication attempts
- Comprehensive test coverage for all session detection scenarios and credential handling

https://claude.ai/code/session_01LWSxjVmEd6w9HGwjveRh3C