### PR TITLE
Fix localStorage tests failing on Node.js v24+ with jsdom

### DIFF
--- a/src/frontend/auth/auth-manager.test.ts
+++ b/src/frontend/auth/auth-manager.test.ts
@@ -1,5 +1,6 @@
 /**
  * @vitest-environment jsdom
+ * @vitest-environment-options { "url": "http://localhost" }
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthManager, ID_TOKEN_STORAGE_KEY } from './auth-manager';

--- a/src/frontend/components/LoginButton.test.tsx
+++ b/src/frontend/components/LoginButton.test.tsx
@@ -1,5 +1,6 @@
 /**
  * @vitest-environment jsdom
+ * @vitest-environment-options { "url": "http://localhost" }
  */
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,28 @@
+// Workaround for jsdom 29.x + Node.js v24+ incompatibility.
+// Node.js v24+ provides an experimental `localStorage` global that lacks
+// the full Storage API (no clear(), no key(), etc.). jsdom 29.x re-uses
+// this broken implementation instead of providing its own. We replace it
+// with a spec-compliant in-memory implementation in jsdom environments.
+if (typeof window !== "undefined") {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    value: {
+      get length() {
+        return store.size;
+      },
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, String(value));
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+    },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     testTimeout: 30000, // 30 seconds for network requests
+    setupFiles: ['src/test-setup.ts'],
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost',
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Node.js v24+ の実験的 `localStorage` と jsdom 29.x の非互換性による `localStorage.clear is not a function` エラーを修正
- jsdom 環境でのみ動作するスペック準拠のインメモリ `localStorage` 実装を `src/test-setup.ts` に追加
- `vitest.config.ts` の `setupFiles` に登録し、jsdom テストファイルで自動適用されるように設定

## Root Cause

Node.js v24+ は実験的な `localStorage` グローバルを提供するが、`null` プロトタイプのオブジェクトで `clear()` や `key()` を実装していない。jsdom 29.x はこれを検出して自前の実装を提供せず、そのまま使用するため `TypeError` が発生していた。

## Test plan

- [x] `auth-manager.test.ts` 6件パス（修正前: 6件失敗）
- [x] `LoginButton.test.tsx` 4件パス（修正前: 4件失敗）
- [x] 既存テスト 102件に影響なし
- [x] lint / typecheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)