### PR TITLE
Remove baseUrl parameter from API client constructors

### DIFF
--- a/src/frontend/components/ShareButton.tsx
+++ b/src/frontend/components/ShareButton.tsx
@@ -2,7 +2,6 @@ import Clipboard from 'clipboard';
 import { useEffect, useRef, useState } from 'react';
 import { getAuthManagerInstance } from '../auth/auth-manager';
 import { useAuth } from '../auth/use-auth';
-import { API_BASE_URL } from '../config';
 import { SharesApiClient } from '../storage/shares-api-client';
 
 // Build the shareable URL for the given share id
@@ -55,10 +54,7 @@ export function ShareButton(props: ShareButtonProps) {
         }
 
         let cancelled = false;
-        const client = new SharesApiClient({
-            baseUrl: API_BASE_URL,
-            getIdToken: () => getAuthManagerInstance().getState().idToken,
-        });
+        const client = new SharesApiClient({ getIdToken: () => getAuthManagerInstance().getState().idToken });
         client
             .create()
             .then((id) => {

--- a/src/frontend/storage/shares-api-client.test.ts
+++ b/src/frontend/storage/shares-api-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { API_BASE_URL } from '../config';
 import { SharesApiClient, SharesApiError } from './shares-api-client';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -14,10 +15,7 @@ describe('SharesApiClient', () => {
 
     beforeEach(() => {
         fetchMock = vi.spyOn(globalThis, 'fetch');
-        client = new SharesApiClient({
-            baseUrl: 'https://api.example.com/',
-            getIdToken: () => 'test-token',
-        });
+        client = new SharesApiClient({ getIdToken: () => 'test-token' });
     });
 
     afterEach(() => {
@@ -31,7 +29,7 @@ describe('SharesApiClient', () => {
 
         expect(shareId).toBe('share-uuid');
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/api/shares',
+            `${API_BASE_URL}/api/shares`,
             expect.objectContaining({
                 method: 'POST',
                 headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
@@ -40,10 +38,7 @@ describe('SharesApiClient', () => {
     });
 
     it('throws SharesApiError without calling fetch when create() has no token', async () => {
-        const noTokenClient = new SharesApiClient({
-            baseUrl: 'https://api.example.com',
-            getIdToken: () => null,
-        });
+        const noTokenClient = new SharesApiClient({ getIdToken: () => null });
 
         await expect(noTokenClient.create()).rejects.toBeInstanceOf(SharesApiError);
         expect(fetchMock).not.toHaveBeenCalled();
@@ -66,7 +61,7 @@ describe('SharesApiClient', () => {
             { stationId: '222', styleId: 4, updatedAt: 2000 },
         ]);
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/shares/share-uuid',
+            `${API_BASE_URL}/shares/share-uuid`,
             expect.objectContaining({ method: 'GET' })
         );
         const init = fetchMock.mock.calls[0][1] as RequestInit;
@@ -79,7 +74,7 @@ describe('SharesApiClient', () => {
         await client.get('a/b c');
 
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/shares/a%2Fb%20c',
+            `${API_BASE_URL}/shares/a%2Fb%20c`,
             expect.anything()
         );
     });

--- a/src/frontend/storage/shares-api-client.ts
+++ b/src/frontend/storage/shares-api-client.ts
@@ -1,7 +1,7 @@
 import type { CreateShareResponse, GetShareResponse, VisitRecord } from '@shared/api-types';
+import { API_BASE_URL } from '../config';
 
 export interface SharesApiClientOptions {
-    baseUrl: string;
     getIdToken: () => string | null;
 }
 
@@ -16,11 +16,9 @@ export class SharesApiError extends Error {
 }
 
 export class SharesApiClient {
-    private readonly baseUrl: string;
     private readonly getIdToken: () => string | null;
 
     constructor(options: SharesApiClientOptions) {
-        this.baseUrl = options.baseUrl.replace(/\/$/, '');
         this.getIdToken = options.getIdToken;
     }
 
@@ -30,7 +28,7 @@ export class SharesApiClient {
             throw new SharesApiError('Missing ID token; user must be signed in');
         }
 
-        const response = await fetch(`${this.baseUrl}/api/shares`, {
+        const response = await fetch(`${API_BASE_URL}/api/shares`, {
             method: 'POST',
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -43,7 +41,7 @@ export class SharesApiClient {
     }
 
     async get(shareId: string): Promise<VisitRecord[]> {
-        const response = await fetch(`${this.baseUrl}/shares/${encodeURIComponent(shareId)}`, {
+        const response = await fetch(`${API_BASE_URL}/shares/${encodeURIComponent(shareId)}`, {
             method: 'GET',
         });
 

--- a/src/frontend/storage/visits-api-client.test.ts
+++ b/src/frontend/storage/visits-api-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { API_BASE_URL } from '../config';
 import { VisitsApiClient, VisitsApiError } from './visits-api-client';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -18,10 +19,7 @@ describe('VisitsApiClient', () => {
 
     beforeEach(() => {
         fetchMock = vi.spyOn(globalThis, 'fetch');
-        client = new VisitsApiClient({
-            baseUrl: 'https://api.example.com/',
-            getIdToken: () => 'test-token',
-        });
+        client = new VisitsApiClient({ getIdToken: () => 'test-token' });
     });
 
     afterEach(() => {
@@ -39,7 +37,7 @@ describe('VisitsApiClient', () => {
 
         expect(visits).toEqual([{ stationId: '123', styleId: 1, updatedAt: 1000 }]);
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/api/visits',
+            `${API_BASE_URL}/api/visits`,
             expect.objectContaining({
                 method: 'GET',
                 headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
@@ -53,7 +51,7 @@ describe('VisitsApiClient', () => {
         await client.put('123', 2);
 
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/api/visits/123',
+            `${API_BASE_URL}/api/visits/123`,
             expect.objectContaining({
                 method: 'PUT',
                 body: JSON.stringify({ styleId: 2 }),
@@ -71,7 +69,7 @@ describe('VisitsApiClient', () => {
         await client.delete('123');
 
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/api/visits/123',
+            `${API_BASE_URL}/api/visits/123`,
             expect.objectContaining({
                 method: 'DELETE',
                 headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
@@ -80,10 +78,7 @@ describe('VisitsApiClient', () => {
     });
 
     it('throws VisitsApiError without calling fetch when ID token is missing', async () => {
-        const noTokenClient = new VisitsApiClient({
-            baseUrl: 'https://api.example.com',
-            getIdToken: () => null,
-        });
+        const noTokenClient = new VisitsApiClient({ getIdToken: () => null });
 
         await expect(noTokenClient.list()).rejects.toBeInstanceOf(VisitsApiError);
         expect(fetchMock).not.toHaveBeenCalled();
@@ -115,7 +110,7 @@ describe('VisitsApiClient', () => {
         await client.put('1 2/3', 1);
 
         expect(fetchMock).toHaveBeenCalledWith(
-            'https://api.example.com/api/visits/1%202%2F3',
+            `${API_BASE_URL}/api/visits/1%202%2F3`,
             expect.anything()
         );
     });

--- a/src/frontend/storage/visits-api-client.ts
+++ b/src/frontend/storage/visits-api-client.ts
@@ -1,7 +1,7 @@
 import type { ListVisitsResponse, PutVisitRequest, VisitRecord } from '@shared/api-types';
+import { API_BASE_URL } from '../config';
 
 export interface VisitsApiClientOptions {
-    baseUrl: string;
     getIdToken: () => string | null;
 }
 
@@ -16,11 +16,9 @@ export class VisitsApiError extends Error {
 }
 
 export class VisitsApiClient {
-    private readonly baseUrl: string;
     private readonly getIdToken: () => string | null;
 
     constructor(options: VisitsApiClientOptions) {
-        this.baseUrl = options.baseUrl.replace(/\/$/, '');
         this.getIdToken = options.getIdToken;
     }
 
@@ -49,7 +47,7 @@ export class VisitsApiClient {
             throw new VisitsApiError('Missing ID token; user must be signed in');
         }
 
-        const response = await fetch(`${this.baseUrl}${path}`, {
+        const response = await fetch(`${API_BASE_URL}${path}`, {
             ...init,
             headers: {
                 ...(init.headers ?? {}),

--- a/src/frontend/style-manager.test.ts
+++ b/src/frontend/style-manager.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { API_BASE_URL } from './config';
 import { StyleManager, createStyleManager } from './style-manager';
 import { MemoryStorage } from './storage/memory-storage';
 import { RemoteStorage } from './storage/remote-storage';
@@ -299,14 +300,13 @@ describe('createStyleManager', () => {
             const manager = await createStyleManager({
                 authState: signedInAuth,
                 getIdToken: () => 'token-abc',
-                apiBaseUrl: 'https://api.example.com',
             });
 
             expect(manager.storage).toBeInstanceOf(MemoryStorage);
             expect(manager.storage.getItem('111')).toBe('1');
             expect(manager.storage.getItem('222')).toBe('4');
             expect(fetchSpy).toHaveBeenCalledWith(
-                'https://api.example.com/shares/abc-123',
+                `${API_BASE_URL}/shares/abc-123`,
                 expect.objectContaining({ method: 'GET' })
             );
         } finally {
@@ -328,13 +328,12 @@ describe('createStyleManager', () => {
             const manager = await createStyleManager({
                 authState: signedInAuth,
                 getIdToken: () => 'token-abc',
-                apiBaseUrl: 'https://api.example.com',
             });
 
             expect(manager.storage).toBeInstanceOf(RemoteStorage);
             expect(manager.storage.getItem('111')).toBe('2');
             expect(fetchSpy).toHaveBeenCalledWith(
-                'https://api.example.com/api/visits',
+                `${API_BASE_URL}/api/visits`,
                 expect.objectContaining({
                     method: 'GET',
                     headers: expect.objectContaining({ Authorization: 'Bearer token-abc' }),

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -1,5 +1,4 @@
 import queryString from 'query-string';
-import { API_BASE_URL } from './config';
 import { MemoryStorage } from './storage/memory-storage';
 import { RemoteStorage } from './storage/remote-storage';
 import { SharesApiClient } from './storage/shares-api-client';
@@ -90,7 +89,6 @@ export class StyleManager {
 export interface CreateStyleManagerOptions {
     authState: AuthState;
     getIdToken: () => string | null;
-    apiBaseUrl?: string;
     onSyncError?: (error: VisitsApiError | Error, stationId: string) => void;
 }
 
@@ -103,13 +101,9 @@ export interface CreateStyleManagerOptions {
  */
 export async function createStyleManager(options: CreateStyleManagerOptions): Promise<StyleManager> {
     const queries = queryString.parse(location.search);
-    const baseUrl = options.apiBaseUrl ?? API_BASE_URL;
 
     if (typeof queries.share === 'string' && queries.share.length > 0) {
-        const sharesClient = new SharesApiClient({
-            baseUrl,
-            getIdToken: options.getIdToken,
-        });
+        const sharesClient = new SharesApiClient({ getIdToken: options.getIdToken });
         const visits = await sharesClient.get(queries.share);
         const entries: Array<[string, string]> = visits.map((visit) => [
             visit.stationId,
@@ -119,10 +113,7 @@ export async function createStyleManager(options: CreateStyleManagerOptions): Pr
     }
 
     if (options.authState.idToken) {
-        const client = new VisitsApiClient({
-            baseUrl,
-            getIdToken: options.getIdToken,
-        });
+        const client = new VisitsApiClient({ getIdToken: options.getIdToken });
         const storage = await RemoteStorage.create({
             client,
             onSyncError: options.onSyncError,


### PR DESCRIPTION
## Summary
Refactored API client initialization to use a centralized `API_BASE_URL` configuration instead of accepting it as a constructor parameter. This simplifies the API client interfaces and reduces configuration duplication across the codebase.

## Key Changes
- **VisitsApiClient**: Removed `baseUrl` parameter from `VisitsApiClientOptions` interface and constructor; now uses imported `API_BASE_URL` constant
- **SharesApiClient**: Removed `baseUrl` parameter from `SharesApiClientOptions` interface and constructor; now uses imported `API_BASE_URL` constant
- **StyleManager**: Removed `apiBaseUrl` optional parameter from `CreateStyleManagerOptions` interface; removed local `baseUrl` variable that was passed to API client constructors
- **ShareButton**: Removed `baseUrl` parameter when instantiating `SharesApiClient`
- **Tests**: Updated all test files to remove hardcoded `baseUrl` values from client instantiation and use `API_BASE_URL` constant in fetch call assertions

## Implementation Details
- The `API_BASE_URL` is now imported from `../config` in all files that need it
- Removed the `baseUrl.replace(/\/$/, '')` normalization logic from both API client constructors since the centralized config should provide a consistent format
- All fetch calls now directly reference `API_BASE_URL` instead of instance variables
- This change makes the API clients simpler and ensures consistent base URL usage across the application

https://claude.ai/code/session_011s2MXUwSyWojJbj1S311cT