### PR TITLE
Refactor StyleManager API from countByStyle to entries

### DIFF
--- a/src/frontend/components/StationCounter.test.tsx
+++ b/src/frontend/components/StationCounter.test.tsx
@@ -14,14 +14,13 @@ import {
 describe('StationCounter', () => {
     it('should render without errors when map is provided', () => {
         setupGoogleMapsMock();
-        
-        const mockStyleManager = createMockStyleManager({
-            0: 96,
-            1: 2,
-            2: 1,
-            3: 0,
-            4: 1
-        });
+
+        const mockStyleManager = createMockStyleManager([
+            ['001', 1],
+            ['002', 1],
+            ['003', 2],
+            ['004', 4],
+        ]);
 
         const mockStations = createMockStations(100);
         const mockMap = createMockMap();
@@ -31,12 +30,12 @@ describe('StationCounter', () => {
         );
 
         expect(container.firstChild).toBeNull(); // Component renders null
-        expect(mockStyleManager.countByStyle).toHaveBeenCalledWith(100);
+        expect(mockStyleManager.entries).toHaveBeenCalled();
         expect(mockMap.controls[7].push).toHaveBeenCalledTimes(1);
     });
 
     it('should not render when map is null', () => {
-        const mockStyleManager = createMockStyleManager({});
+        const mockStyleManager = createMockStyleManager();
         const mockStations = createMockStations(100);
 
         const { container } = render(
@@ -44,24 +43,29 @@ describe('StationCounter', () => {
         );
 
         expect(container.firstChild).toBeNull();
-        expect(mockStyleManager.countByStyle).not.toHaveBeenCalled();
+        expect(mockStyleManager.entries).not.toHaveBeenCalled();
     });
 
     it('should return null when stations is null', () => {
-        const mockStyleManager = createMockStyleManager({});
+        const mockStyleManager = createMockStyleManager();
 
         const { container } = render(
             <StationCounter styleManager={mockStyleManager} stations={null} styleVersion={0} map={null} />
         );
 
         expect(container.firstChild).toBeNull();
-        expect(mockStyleManager.countByStyle).not.toHaveBeenCalled();
+        expect(mockStyleManager.entries).not.toHaveBeenCalled();
     });
 
     it('should re-render when styleVersion changes', () => {
         setupGoogleMapsMock();
-        
-        const mockStyleManager = createMockStyleManager({ 0: 96, 1: 2, 2: 1, 3: 0, 4: 1 });
+
+        const mockStyleManager = createMockStyleManager([
+            ['001', 1],
+            ['002', 1],
+            ['003', 2],
+            ['004', 4],
+        ]);
         const mockStations = createMockStations(100);
         const mockMap = createMockMap();
 
@@ -69,13 +73,13 @@ describe('StationCounter', () => {
             <StationCounter styleManager={mockStyleManager} stations={mockStations} styleVersion={0} map={mockMap} />
         );
 
-        expect(mockStyleManager.countByStyle).toHaveBeenCalledTimes(1);
+        expect(mockStyleManager.entries).toHaveBeenCalledTimes(1);
 
         // styleVersionを変更して再レンダリング
         rerender(
             <StationCounter styleManager={mockStyleManager} stations={mockStations} styleVersion={1} map={mockMap} />
         );
 
-        expect(mockStyleManager.countByStyle).toHaveBeenCalledTimes(2);
+        expect(mockStyleManager.entries).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/frontend/components/StationCounter.tsx
+++ b/src/frontend/components/StationCounter.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { MARKER_ICONS } from '../marker-icons';
-import { StyleManager } from '../style-manager';
+import { STYLE_COUNT, StyleManager } from '../style-manager';
 import { StationsGeoJSON } from '../types/geojson';
 
 interface StationCounterProps {
@@ -9,6 +9,23 @@ interface StationCounterProps {
     stations: StationsGeoJSON | null;
     styleVersion: number;
     map: google.maps.Map | null;
+}
+
+function countByStyle(styleManager: StyleManager, totalStations: number): Record<number, number> {
+    const counts: Record<number, number> = {};
+    for (let i = 0; i < STYLE_COUNT; i++) {
+        counts[i] = 0;
+    }
+
+    for (const [, styleId] of styleManager.entries()) {
+        counts[styleId]++;
+    }
+
+    // StyleId 0 = total stations - assigned stations
+    const assignedCount = Object.values(counts).reduce((sum, count) => sum + count, 0) - counts[0];
+    counts[0] = totalStations - assignedCount;
+
+    return counts;
 }
 
 export function StationCounter({ styleManager, stations, styleVersion: _styleVersion, map }: StationCounterProps) {
@@ -21,7 +38,7 @@ export function StationCounter({ styleManager, stations, styleVersion: _styleVer
         // Create counter container
         contentElementRef.current = document.createElement('div');
         contentElementRef.current.className = 'station-counter';
-        
+
         contentRootRef.current = createRoot(contentElementRef.current);
 
         // Add to map controls
@@ -32,7 +49,7 @@ export function StationCounter({ styleManager, stations, styleVersion: _styleVer
         if (!contentRootRef.current || !stations) return;
 
         const totalStations = stations.features.length;
-        const counts = styleManager.countByStyle(totalStations);
+        const counts = countByStyle(styleManager, totalStations);
 
         // Render React content
         contentRootRef.current.render(

--- a/src/frontend/style-manager.test.ts
+++ b/src/frontend/style-manager.test.ts
@@ -132,53 +132,24 @@ describe('StyleManager', () => {
         });
     });
 
-    describe('countByStyle', () => {
-        it('should return all stations as style 0 when no styles are stored', () => {
+    describe('entries', () => {
+        it('should return an empty array when no styles are stored', () => {
             const storage = new MemoryStorage();
             const styleManager = new StyleManager(storage);
 
-            const counts = styleManager.countByStyle(100);
-
-            expect(counts).toEqual({ 0: 100, 1: 0, 2: 0, 3: 0, 4: 0 });
+            expect(styleManager.entries()).toEqual([]);
         });
 
-        it('should count stored styles correctly', () => {
+        it('should return [stationId, styleId] pairs for stored styles', () => {
             const storage = new MemoryStorage();
-            storage.setItem('001', '1');  // blue
-            storage.setItem('002', '1');  // blue
-            storage.setItem('003', '2');  // purple
-            storage.setItem('004', '4');  // green
+            storage.setItem('001', '1');
+            storage.setItem('002', '4');
             const styleManager = new StyleManager(storage);
 
-            const counts = styleManager.countByStyle(100);
-
-            expect(counts).toEqual({ 0: 96, 1: 2, 2: 1, 3: 0, 4: 1 });
-        });
-
-        it('should calculate style 0 count correctly', () => {
-            const storage = new MemoryStorage();
-            storage.setItem('001', '2');  // purple stored
-            storage.setItem('002', '3');  // yellow stored
-            const styleManager = new StyleManager(storage);
-
-            const counts = styleManager.countByStyle(10);
-
-            expect(counts).toEqual({ 0: 8, 1: 0, 2: 1, 3: 1, 4: 0 });
-        });
-
-        it('should handle mixed storage scenarios', () => {
-            const storage = new MemoryStorage();
-            storage.setItem('station1', '0');
-            storage.setItem('station2', '1');
-            storage.setItem('station3', '2');
-            storage.setItem('station4', '3');
-            storage.setItem('station5', '4');
-            storage.setItem('station6', '1');
-            const styleManager = new StyleManager(storage);
-
-            const counts = styleManager.countByStyle(20);
-
-            expect(counts).toEqual({ 0: 15, 1: 2, 2: 1, 3: 1, 4: 1 });
+            expect(styleManager.entries().sort()).toEqual([
+                ['001', 1],
+                ['002', 4],
+            ]);
         });
     });
 

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -43,23 +43,8 @@ export class StyleManager {
         return 0;
     }
 
-    countByStyle(totalStations: number): Record<number, number> {
-        const counts: Record<number, number> = {};
-        for (let i = 0; i < STYLE_COUNT; i++) {
-            counts[i] = 0;
-        }
-
-        const stationIds = this.storage.listItems();
-        stationIds.forEach(stationId => {
-            const styleId = this.getStyle(stationId);
-            counts[styleId]++;
-        });
-
-        // StyleId 0 = total stations - assigned stations
-        const assignedCount = Object.values(counts).reduce((sum, count) => sum + count, 0) - counts[0];
-        counts[0] = totalStations - assignedCount;
-
-        return counts;
+    entries(): Array<[string, number]> {
+        return this.storage.listItems().map((stationId) => [stationId, this.getStyle(stationId)]);
     }
 }
 

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -98,8 +98,8 @@ export const createMockStations = (count: number, startId: number = 18786) => ({
 });
 
 // Create mock StyleManager
-export const createMockStyleManager = (countByStyleReturnValue: Record<number, number>) => ({
-    countByStyle: vi.fn().mockReturnValue(countByStyleReturnValue),
+export const createMockStyleManager = (entries: Array<[string, number]> = []) => ({
+    entries: vi.fn().mockReturnValue(entries),
     getStyle: vi.fn(),
     changeStyle: vi.fn(),
     resetStyle: vi.fn(),


### PR DESCRIPTION
## Summary
Refactored the StyleManager API to provide a more granular `entries()` method instead of the higher-level `countByStyle()` method. The counting logic has been moved to the consumer (StationCounter component) for better separation of concerns.

## Key Changes
- **StyleManager**: Replaced `countByStyle(totalStations)` method with `entries()` that returns an array of `[stationId, styleId]` tuples
- **StationCounter**: Moved the style counting logic into a local `countByStyle()` helper function that uses the new `entries()` API
- **Tests**: Updated all test cases to reflect the new API:
  - StyleManager tests now verify `entries()` returns correct station-style pairs
  - StationCounter tests updated to mock and verify calls to `entries()` instead of `countByStyle()`
  - Test utilities updated to create mock StyleManager with entries data

## Implementation Details
- The new `entries()` method is simpler and more composable - it just returns the raw data without business logic
- The counting logic remains functionally identical but is now encapsulated in StationCounter where it's used
- This change improves testability by separating data retrieval from data transformation

https://claude.ai/code/session_01AsqBpHCC4LMsuxWi5LPtCQ