### PR TITLE
Replace onSyncError callback with console.error logging

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -68,9 +68,6 @@ export function RoadStationMap() {
         createStyleManager({
             authState: auth,
             getIdToken: () => authManager.getState().idToken,
-            onSyncError: (error) => {
-                console.error('Failed to sync visit:', error);
-            },
         })
             .then((manager) => {
                 if (cancelled) return;

--- a/src/frontend/storage/remote-storage.test.ts
+++ b/src/frontend/storage/remote-storage.test.ts
@@ -101,23 +101,24 @@ describe('RemoteStorage', () => {
         expect(client.put).toHaveBeenCalledWith('222', 4);
     });
 
-    it('reports sync errors via the onSyncError callback without throwing', async () => {
+    it('logs sync errors to console without throwing', async () => {
         const client = createClient();
-        client.put.mockRejectedValueOnce(new VisitsApiError('boom', 500));
-        const onSyncError = vi.fn();
+        const apiError = new VisitsApiError('boom', 500);
+        client.put.mockRejectedValueOnce(apiError);
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
         const storage = await RemoteStorage.create({
             client: client as unknown as VisitsApiClient,
             debounceMs: 0,
-            onSyncError,
         });
 
         storage.setItem('111', '1');
         await storage.flush();
 
-        expect(onSyncError).toHaveBeenCalledTimes(1);
-        const [error, stationId] = onSyncError.mock.calls[0];
-        expect(error).toBeInstanceOf(VisitsApiError);
-        expect(stationId).toBe('111');
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        expect(consoleError).toHaveBeenCalledWith('Failed to sync visit:', apiError, {
+            stationId: '111',
+        });
+        consoleError.mockRestore();
     });
 
     it('removeItem on a station with no cache entry does not call the API', async () => {

--- a/src/frontend/storage/remote-storage.ts
+++ b/src/frontend/storage/remote-storage.ts
@@ -1,5 +1,5 @@
 import type { Storage } from './types';
-import { VisitsApiClient, VisitsApiError } from './visits-api-client';
+import { VisitsApiClient } from './visits-api-client';
 
 const DEFAULT_DEBOUNCE_MS = 400;
 
@@ -8,7 +8,6 @@ type PendingOp = { kind: 'put'; styleId: number } | { kind: 'delete' };
 export interface RemoteStorageOptions {
     client: VisitsApiClient;
     debounceMs?: number;
-    onSyncError?: (error: VisitsApiError | Error, stationId: string) => void;
     setTimeoutImpl?: typeof setTimeout;
     clearTimeoutImpl?: typeof clearTimeout;
 }
@@ -27,14 +26,12 @@ export class RemoteStorage implements Storage {
     private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly client: VisitsApiClient;
     private readonly debounceMs: number;
-    private readonly onSyncError: (error: VisitsApiError | Error, stationId: string) => void;
     private readonly setTimeoutImpl: typeof setTimeout;
     private readonly clearTimeoutImpl: typeof clearTimeout;
 
     private constructor(options: RemoteStorageOptions) {
         this.client = options.client;
         this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
-        this.onSyncError = options.onSyncError ?? (() => {});
         this.setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
         this.clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
     }
@@ -118,9 +115,7 @@ export class RemoteStorage implements Storage {
                 await this.client.delete(stationId);
             }
         } catch (error) {
-            const normalized =
-                error instanceof Error ? error : new Error(`Sync failed for station ${stationId}`);
-            this.onSyncError(normalized, stationId);
+            console.error('Failed to sync visit:', error, { stationId });
         }
     }
 }

--- a/src/frontend/style-manager.ts
+++ b/src/frontend/style-manager.ts
@@ -3,7 +3,7 @@ import { MemoryStorage } from './storage/memory-storage';
 import { RemoteStorage } from './storage/remote-storage';
 import { SharesApiClient } from './storage/shares-api-client';
 import { Storage } from './storage/types';
-import { VisitsApiClient, type VisitsApiError } from './storage/visits-api-client';
+import { VisitsApiClient } from './storage/visits-api-client';
 import { RoadStation } from './road-station';
 import type { AuthState } from '@shared/auth-types';
 
@@ -51,7 +51,6 @@ export class StyleManager {
 export interface CreateStyleManagerOptions {
     authState: AuthState;
     getIdToken: () => string | null;
-    onSyncError?: (error: VisitsApiError | Error, stationId: string) => void;
 }
 
 /**
@@ -76,10 +75,7 @@ export async function createStyleManager(options: CreateStyleManagerOptions): Pr
 
     if (options.authState.idToken) {
         const client = new VisitsApiClient({ getIdToken: options.getIdToken });
-        const storage = await RemoteStorage.create({
-            client,
-            onSyncError: options.onSyncError,
-        });
+        const storage = await RemoteStorage.create({ client });
 
         return new StyleManager(storage);
     }


### PR DESCRIPTION
## Summary
This PR removes the `onSyncError` callback pattern from the remote storage error handling and replaces it with direct `console.error` logging. This simplifies the error handling API by removing the need for consumers to pass error callbacks.

## Key Changes
- **RemoteStorage**: Removed `onSyncError` option from `RemoteStorageOptions` interface and constructor
- **Error handling**: Changed from invoking `this.onSyncError()` callback to calling `console.error()` directly with error details and station ID context
- **StyleManager**: Removed `onSyncError` option from `CreateStyleManagerOptions` interface and its usage when creating RemoteStorage
- **RoadStationMap**: Removed the `onSyncError` callback handler that was previously passed to `createStyleManager()`
- **Tests**: Updated test expectations to verify `console.error` is called with the correct error and context object instead of verifying callback invocation

## Implementation Details
- Error logging now includes the error object and a context object with `stationId` for better debugging
- The change maintains the same error handling behavior (errors are logged but don't throw) while simplifying the API surface
- All error information is preserved in the console output for debugging purposes

https://claude.ai/code/session_01TosNfk9AMRHpAH23hMvcRT