### PR TITLE
Fix memory leaks in StationCounter by adding proper cleanup

### DIFF
--- a/src/frontend/components/StationCounter.tsx
+++ b/src/frontend/components/StationCounter.tsx
@@ -36,13 +36,27 @@ export function StationCounter({ styleManager, stations, styleVersion: _styleVer
         if (!map) return;
 
         // Create counter container
-        contentElementRef.current = document.createElement('div');
-        contentElementRef.current.className = 'station-counter';
+        const element = document.createElement('div');
+        element.className = 'station-counter';
+        contentElementRef.current = element;
 
-        contentRootRef.current = createRoot(contentElementRef.current);
+        const root = createRoot(element);
+        contentRootRef.current = root;
 
         // Add to map controls
-        map.controls[google.maps.ControlPosition.RIGHT_TOP].push(contentElementRef.current);
+        const controls = map.controls[google.maps.ControlPosition.RIGHT_TOP];
+        controls.push(element);
+
+        return () => {
+            const index = controls.getArray().indexOf(element);
+            if (index >= 0) {
+                controls.removeAt(index);
+            }
+            // Defer unmount to avoid synchronous unmount during React render
+            setTimeout(() => root.unmount(), 0);
+            contentElementRef.current = null;
+            contentRootRef.current = null;
+        };
     }, [map]);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
This PR fixes memory leaks in the StationCounter component by implementing proper cleanup logic for DOM elements and React roots when the component unmounts or the map reference changes.

## Key Changes
- **Refactored element creation**: Separated variable assignments to improve code clarity and enable proper cleanup reference tracking
- **Added cleanup function**: Implemented a return statement in the useEffect hook that:
  - Removes the counter element from the map controls array
  - Safely unmounts the React root with a deferred timeout to avoid synchronous unmount during render
  - Clears ref values to prevent stale references
- **Improved control management**: Extracted map controls reference to a local variable for cleaner removal logic

## Implementation Details
- The cleanup function uses `controls.getArray().indexOf()` to safely locate and remove the element before unmounting
- React root unmounting is deferred with `setTimeout(..., 0)` to prevent issues with synchronous unmounting during React's render phase
- Refs are explicitly nullified to ensure they don't hold stale references after cleanup

https://claude.ai/code/session_018VP9dEq6BKoSB5LzimwybA