### PR TITLE
Fix ESM compatibility in esbuild.config.ts

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
 // Common configuration
@@ -18,7 +19,7 @@ const config: esbuild.BuildOptions = {
     sourcemap: true,
     minify: true,
     alias: {
-        '@shared': path.resolve(__dirname, 'src/shared'),
+        '@shared': path.resolve(import.meta.dirname, 'src/shared'),
     },
     define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
@@ -58,7 +59,7 @@ const serve = (): Promise<esbuild.ServeResult> => {
 export { build, watch, serve, config };
 
 // CLI handling
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
     const args = process.argv.slice(2);
     
     if (args.includes('--watch')) {


### PR DESCRIPTION
## Summary

- `package.json` の `"type": "module"` によりファイルがESMとして扱われるため、`__dirname` と `require.main` が使用不可になっていた
- `__dirname` を `import.meta.dirname` に置換（Node.js 21.2+ 対応）
- `require.main === module` を `process.argv[1] === fileURLToPath(import.meta.url)` に置換

## Test plan

- [ ] CI の `npm run build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)