### PR TITLE
Add flush method to Storage interface and implementations

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAuthManager } from '../auth/auth-context';
 import { reconcileVisits } from '../reconcile-visits';
-import { createStorage, RemoteStorage, type Storage } from '../storage';
+import { createStorage, type Storage } from '../storage';
 import { StationsGeoJSON } from '../types/geojson';
 import { ShareButton } from './ShareButton';
 import { InfoWindow } from './InfoWindow';
@@ -57,9 +57,7 @@ export function RoadStationMap() {
     useEffect(() => {
         let cancelled = false;
         setStorage((previous) => {
-            if (previous instanceof RemoteStorage) {
-                void previous.flush();
-            }
+            void previous?.flush();
             return null;
         });
         setLoadError(null);

--- a/src/frontend/storage/memory-storage.ts
+++ b/src/frontend/storage/memory-storage.ts
@@ -28,4 +28,6 @@ export class MemoryStorage implements Storage {
     listItems(): string[] {
         return Array.from(this.storage.keys());
     }
+
+    async flush(): Promise<void> {}
 }

--- a/src/frontend/storage/types.ts
+++ b/src/frontend/storage/types.ts
@@ -3,4 +3,5 @@ export interface Storage {
     setItem(key: string, value: string): void;
     removeItem(key: string): void;
     listItems(): string[];
+    flush(): Promise<void>;
 }


### PR DESCRIPTION
## Summary
This PR adds a `flush()` method to the Storage interface and updates all implementations to support it. The change simplifies storage cleanup logic by providing a consistent async interface for flushing pending operations.

## Key Changes
- Added `flush(): Promise<void>` method to the Storage interface
- Implemented `flush()` in MemoryStorage as a no-op async method
- Updated RoadStationMap to call `flush()` on any storage instance without type checking, removing the dependency on RemoteStorage class
- Removed unused RemoteStorage import from RoadStationMap

## Implementation Details
- The flush method is now part of the Storage contract, allowing all storage implementations to define their own flush behavior
- MemoryStorage provides a no-op implementation since it doesn't require explicit flushing
- The RoadStationMap cleanup logic is simplified by removing the `instanceof RemoteStorage` check and calling flush on any truthy storage instance
- This change decouples RoadStationMap from the concrete RemoteStorage class, improving modularity

https://claude.ai/code/session_013hFW5Ruw88hKzJvyZWxgC3