### PR TITLE
Simplify style functions to accept only string station IDs

### DIFF
--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { createRoadStation } from '../road-station';
 import { MARKER_ICONS } from '../marker-icons';
 import type { Storage } from '../storage';
 import { changeStyle, getStyle, resetStyle } from '../style';
@@ -33,8 +32,8 @@ export function Markers(props: MarkersProps) {
         storageRef.current = props.storage;
         if (!props.map) return;
         props.map.data.setStyle((feature: google.maps.Data.Feature) => {
-            const station = createRoadStation(feature);
-            return styleOptionsFor(getStyle(storageRef.current, station));
+            const stationId = feature.getProperty('stationId') as string;
+            return styleOptionsFor(getStyle(storageRef.current, stationId));
         });
     }, [props.map, props.storage]);
 
@@ -46,8 +45,8 @@ export function Markers(props: MarkersProps) {
         const doubleClickListener = props.map.data.addListener('dblclick', onMarkerDoubleClick);
         const rightClickListener = props.map.data.addListener('rightclick', onMarkerRightClick);
         props.map.data.setStyle((feature: google.maps.Data.Feature) => {
-            const station = createRoadStation(feature);
-            return styleOptionsFor(getStyle(storageRef.current, station));
+            const stationId = feature.getProperty('stationId') as string;
+            return styleOptionsFor(getStyle(storageRef.current, stationId));
         });
 
         return () => {
@@ -59,8 +58,8 @@ export function Markers(props: MarkersProps) {
 
     const onMarkerClick = (event: google.maps.Data.MouseEvent) => {
         if (props.map && selectedFeatureRef.current === event.feature) {
-            const station = createRoadStation(event.feature);
-            const newStyleId = changeStyle(storageRef.current, station);
+            const stationId = event.feature.getProperty('stationId') as string;
+            const newStyleId = changeStyle(storageRef.current, stationId);
             props.map.data.overrideStyle(event.feature, styleOptionsFor(newStyleId));
             props.onStyleChange();
         } else {
@@ -70,8 +69,8 @@ export function Markers(props: MarkersProps) {
 
     const onMarkerDoubleClick = (event: google.maps.Data.MouseEvent) => {
         if (props.map) {
-            const station = createRoadStation(event.feature);
-            const newStyleId = changeStyle(storageRef.current, station);
+            const stationId = event.feature.getProperty('stationId') as string;
+            const newStyleId = changeStyle(storageRef.current, stationId);
             props.map.data.overrideStyle(event.feature, styleOptionsFor(newStyleId));
             props.onStyleChange();
         }
@@ -79,8 +78,8 @@ export function Markers(props: MarkersProps) {
 
     const onMarkerRightClick = (event: google.maps.Data.MouseEvent) => {
         if (props.map) {
-            const station = createRoadStation(event.feature);
-            const newStyleId = resetStyle(storageRef.current, station);
+            const stationId = event.feature.getProperty('stationId') as string;
+            const newStyleId = resetStyle(storageRef.current, stationId);
             props.map.data.overrideStyle(event.feature, styleOptionsFor(newStyleId));
             props.onFeatureSelect(null);
             props.onStyleChange();

--- a/src/frontend/style.test.ts
+++ b/src/frontend/style.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { changeStyle, entries, getStyle, resetStyle } from './style';
 import { MemoryStorage } from './storage';
-import { createMockStation } from '../test-utils/test-utils';
 
 describe('getStyle', () => {
     it('should return 0 when no style is stored', () => {
@@ -15,21 +14,6 @@ describe('getStyle', () => {
         storage.setItem('002', '2');
 
         expect(getStyle(storage, '002')).toBe(2);
-    });
-
-    it('should accept RoadStation object when style is stored', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('003');
-        storage.setItem('003', '1');
-
-        expect(getStyle(storage, station)).toBe(1);
-    });
-
-    it('should accept RoadStation object when no style is stored', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('004');
-
-        expect(getStyle(storage, station)).toBe(0);
     });
 });
 
@@ -64,23 +48,6 @@ describe('changeStyle', () => {
         expect(changeStyle(storage, '004')).toBe(1);
         expect(storage.getItem('004')).toBe('1');
     });
-
-    it('should accept RoadStation object with stored style', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('005');
-        storage.setItem('005', '2');
-
-        expect(changeStyle(storage, station)).toBe(3);
-        expect(storage.getItem('005')).toBe('3');
-    });
-
-    it('should accept RoadStation object with no stored style', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('006');
-
-        expect(changeStyle(storage, station)).toBe(1);
-        expect(storage.getItem('006')).toBe('1');
-    });
 });
 
 describe('resetStyle', () => {
@@ -90,23 +57,6 @@ describe('resetStyle', () => {
 
         expect(resetStyle(storage, '001')).toBe(0);
         expect(storage.getItem('001')).toBeNull();
-    });
-
-    it('should accept RoadStation object with stored style', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('002');
-        storage.setItem('002', '2');
-
-        expect(resetStyle(storage, station)).toBe(0);
-        expect(storage.getItem('002')).toBeNull();
-    });
-
-    it('should accept RoadStation object with no stored style', () => {
-        const storage = new MemoryStorage();
-        const station = createMockStation('003');
-
-        expect(resetStyle(storage, station)).toBe(0);
-        expect(storage.getItem('003')).toBeNull();
     });
 });
 

--- a/src/frontend/style.ts
+++ b/src/frontend/style.ts
@@ -1,15 +1,9 @@
-import { RoadStation } from './road-station';
 import type { Storage } from './storage';
 
 export const STYLE_COUNT = 5;
 const MAX_STYLE_ID = STYLE_COUNT - 1;
 
-function getStationId(station: RoadStation | string): string {
-    return typeof station === 'string' ? station : station.stationId;
-}
-
-export function getStyle(storage: Storage, station: RoadStation | string): number {
-    const stationId = getStationId(station);
+export function getStyle(storage: Storage, stationId: string): number {
     const styleId = storage.getItem(stationId);
     if (styleId) {
         return parseInt(styleId);
@@ -17,8 +11,7 @@ export function getStyle(storage: Storage, station: RoadStation | string): numbe
     return 0;
 }
 
-export function changeStyle(storage: Storage, station: RoadStation | string): number {
-    const stationId = getStationId(station);
+export function changeStyle(storage: Storage, stationId: string): number {
     const current = getStyle(storage, stationId);
     if (current >= MAX_STYLE_ID) {
         return resetStyle(storage, stationId);
@@ -28,8 +21,7 @@ export function changeStyle(storage: Storage, station: RoadStation | string): nu
     return next;
 }
 
-export function resetStyle(storage: Storage, station: RoadStation | string): number {
-    const stationId = getStationId(station);
+export function resetStyle(storage: Storage, stationId: string): number {
     storage.removeItem(stationId);
     return 0;
 }


### PR DESCRIPTION
## Summary
Refactored the style management functions to accept only string station IDs instead of supporting both `RoadStation` objects and strings. This simplifies the API and removes unnecessary abstraction.

## Key Changes
- **style.ts**: Removed `RoadStation` type parameter support from `getStyle()`, `changeStyle()`, and `resetStyle()` functions. These now accept only `string` station IDs.
- **Markers.tsx**: Updated all calls to style functions to extract the `stationId` property directly from map features instead of creating `RoadStation` objects. Removed the `createRoadStation()` import.
- **style.test.ts**: Removed 6 test cases that verified the functions could accept `RoadStation` objects. Kept tests that verify string-based functionality.

## Implementation Details
- The `getStationId()` helper function was removed as it's no longer needed
- Callers now explicitly extract `stationId` from features using `feature.getProperty('stationId') as string`
- This change reduces coupling between the style module and the `RoadStation` type, making the code more straightforward and easier to test

https://claude.ai/code/session_01PXVJaWCzCjKW4ijuKuEKfC