### PR TITLE
Delay GoogleLogin rendering until SilentSignIn settles

### DIFF
--- a/src/frontend/auth/SilentSignIn.test.tsx
+++ b/src/frontend/auth/SilentSignIn.test.tsx
@@ -7,8 +7,16 @@ import { AuthProvider } from './auth-context';
 import { AuthManager, ID_TOKEN_STORAGE_KEY } from './auth-manager';
 import { GOOGLE_CLIENT_ID } from '../config';
 
+interface PromptMomentNotification {
+    isNotDisplayed: () => boolean;
+    isSkippedMoment: () => boolean;
+    isDismissedMoment: () => boolean;
+}
+
 interface OneTapOptions {
     onSuccess: (response: { credential?: string }) => void;
+    onError?: () => void;
+    promptMomentNotification?: (notification: PromptMomentNotification) => void;
     auto_select?: boolean;
     disabled?: boolean;
 }
@@ -88,5 +96,57 @@ describe('SilentSignIn', () => {
         lastOneTapOptions?.onSuccess({ credential: newToken });
 
         expect(handleCredential).toHaveBeenCalledWith(newToken);
+    });
+
+    it('marks silent sign-in settled after a successful response', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const { manager } = renderWithAuth(<SilentSignIn />);
+        expect(manager.silentSignInSettled).toBe(false);
+
+        lastOneTapOptions?.onSuccess({ credential: validToken({ sub: 'user-2' }) });
+
+        expect(manager.silentSignInSettled).toBe(true);
+    });
+
+    it('marks silent sign-in settled when the prompt is not displayed', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const { manager } = renderWithAuth(<SilentSignIn />);
+        expect(manager.silentSignInSettled).toBe(false);
+
+        lastOneTapOptions?.promptMomentNotification?.({
+            isNotDisplayed: () => true,
+            isSkippedMoment: () => false,
+            isDismissedMoment: () => false,
+        });
+
+        expect(manager.silentSignInSettled).toBe(true);
+    });
+
+    it('marks silent sign-in settled when the prompt is dismissed', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const { manager } = renderWithAuth(<SilentSignIn />);
+        expect(manager.silentSignInSettled).toBe(false);
+
+        lastOneTapOptions?.promptMomentNotification?.({
+            isNotDisplayed: () => false,
+            isSkippedMoment: () => false,
+            isDismissedMoment: () => true,
+        });
+
+        expect(manager.silentSignInSettled).toBe(true);
+    });
+
+    it('marks silent sign-in settled on error', () => {
+        window.localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const { manager } = renderWithAuth(<SilentSignIn />);
+        expect(manager.silentSignInSettled).toBe(false);
+
+        lastOneTapOptions?.onError?.();
+
+        expect(manager.silentSignInSettled).toBe(true);
     });
 });

--- a/src/frontend/auth/SilentSignIn.tsx
+++ b/src/frontend/auth/SilentSignIn.tsx
@@ -5,6 +5,13 @@ import { useAuthManager } from './auth-context';
 // Only enabled when the user previously had a session (token in storage at
 // startup, or a successful login earlier in this session) so that first-time
 // visitors are not prompted unexpectedly.
+//
+// While this attempt is in flight, LoginButton must not render <GoogleLogin>
+// because GoogleLogin internally calls google.accounts.id.initialize() without
+// auto_select, which would overwrite our auto_select=true configuration before
+// the One Tap prompt resolves. We notify AuthManager once the attempt has
+// settled (success or any prompt-moment notification) so LoginButton can then
+// safely render.
 export function SilentSignIn() {
     const manager = useAuthManager();
     const shouldAttempt = !manager.getState().user && manager.hadPreviousSession;
@@ -13,6 +20,19 @@ export function SilentSignIn() {
         onSuccess: (response) => {
             if (response.credential) {
                 manager.handleCredential(response.credential);
+            }
+            manager.markSilentSignInSettled();
+        },
+        onError: () => {
+            manager.markSilentSignInSettled();
+        },
+        promptMomentNotification: (notification) => {
+            if (
+                notification.isNotDisplayed() ||
+                notification.isSkippedMoment() ||
+                notification.isDismissedMoment()
+            ) {
+                manager.markSilentSignInSettled();
             }
         },
         auto_select: true,

--- a/src/frontend/auth/auth-context.tsx
+++ b/src/frontend/auth/auth-context.tsx
@@ -17,10 +17,13 @@ export function useAuthManager(): AuthManager {
     if (!manager) {
         throw new Error('useAuthManager must be used within an AuthProvider');
     }
-    // Subscribe to state changes so consumers re-render on login/logout.
+    // Subscribe to manager notifications so consumers re-render on login/logout
+    // or when other observable fields (e.g. silentSignInSettled) change. The
+    // snapshot is a version counter that increments on every notify so
+    // useSyncExternalStore can detect changes regardless of which field moved.
     useSyncExternalStore(
         (callback) => manager.subscribe(callback),
-        () => manager.getState()
+        () => manager.getRevision()
     );
     return manager;
 }

--- a/src/frontend/auth/auth-manager.test.ts
+++ b/src/frontend/auth/auth-manager.test.ts
@@ -177,6 +177,63 @@ describe('AuthManager', () => {
         expect(manager.hadPreviousSession).toBe(true);
     });
 
+    it('marks silent sign-in settled immediately when there is no previous session', () => {
+        const manager = new AuthManager(CLIENT_ID);
+
+        expect(manager.silentSignInSettled).toBe(true);
+    });
+
+    it('starts with silent sign-in unsettled when an expired token is rehydrated', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+
+        const manager = new AuthManager(CLIENT_ID);
+
+        expect(manager.silentSignInSettled).toBe(false);
+    });
+
+    it('marks silent sign-in settled and notifies listeners on markSilentSignInSettled', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+        const manager = new AuthManager(CLIENT_ID);
+        const listener = vi.fn();
+        manager.subscribe(listener);
+
+        manager.markSilentSignInSettled();
+
+        expect(manager.silentSignInSettled).toBe(true);
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-notify when markSilentSignInSettled is called twice', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+        const manager = new AuthManager(CLIENT_ID);
+        const listener = vi.fn();
+        manager.subscribe(listener);
+
+        manager.markSilentSignInSettled();
+        manager.markSilentSignInSettled();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks silent sign-in settled when handleCredential succeeds', () => {
+        localStorage.setItem(ID_TOKEN_STORAGE_KEY, validToken({ exp: 1000 }));
+        const manager = new AuthManager(CLIENT_ID);
+        expect(manager.silentSignInSettled).toBe(false);
+
+        manager.handleCredential(validToken());
+
+        expect(manager.silentSignInSettled).toBe(true);
+    });
+
+    it('increments revision on each notify so subscribers can detect changes', () => {
+        const manager = new AuthManager(CLIENT_ID);
+        const initial = manager.getRevision();
+
+        manager.handleCredential(validToken());
+
+        expect(manager.getRevision()).toBeGreaterThan(initial);
+    });
+
     it('allows unsubscribing listeners', () => {
         const manager = new AuthManager(CLIENT_ID);
 

--- a/src/frontend/auth/auth-manager.ts
+++ b/src/frontend/auth/auth-manager.ts
@@ -5,18 +5,28 @@ export const ID_TOKEN_STORAGE_KEY = 'auth:idToken';
 
 const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
 
-type Listener = (state: AuthState) => void;
+type Listener = () => void;
 
 export class AuthManager {
     private state: AuthState = { user: null, idToken: null };
     private listeners: Set<Listener> = new Set();
+    private revision = 0;
     // True if the user was authenticated in this session or had a (possibly
     // expired) token in storage at startup. Used to gate silent re-login
     // attempts so brand-new visitors are not prompted unexpectedly.
     hadPreviousSession = false;
+    // True once SilentSignIn has finished its attempt (success, failure, or
+    // skipped because the user is signed in). Used to delay rendering the
+    // explicit GoogleLogin button so that GoogleLogin's
+    // google.accounts.id.initialize call does not overwrite SilentSignIn's
+    // auto_select=true configuration before Google's One Tap can act on it.
+    silentSignInSettled = false;
 
     constructor(private readonly clientId: string) {
         this.rehydrateFromStorage();
+        if (!this.hadPreviousSession) {
+            this.silentSignInSettled = true;
+        }
     }
 
     handleCredential(idToken: string): void {
@@ -24,11 +34,22 @@ export class AuthManager {
         if (!user) return;
         localStorage.setItem(ID_TOKEN_STORAGE_KEY, idToken);
         this.hadPreviousSession = true;
+        this.silentSignInSettled = true;
         this.setState({ user, idToken });
+    }
+
+    markSilentSignInSettled(): void {
+        if (this.silentSignInSettled) return;
+        this.silentSignInSettled = true;
+        this.notify();
     }
 
     getState(): AuthState {
         return this.state;
+    }
+
+    getRevision(): number {
+        return this.revision;
     }
 
     subscribe(listener: Listener): () => void {
@@ -77,8 +98,13 @@ export class AuthManager {
 
     private setState(next: AuthState): void {
         this.state = next;
+        this.notify();
+    }
+
+    private notify(): void {
+        this.revision += 1;
         for (const listener of this.listeners) {
-            listener(next);
+            listener();
         }
     }
 }

--- a/src/frontend/components/LoginButton.tsx
+++ b/src/frontend/components/LoginButton.tsx
@@ -12,6 +12,11 @@ export function LoginButton({ map }: LoginButtonProps) {
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
     const authManager = useAuthManager();
     const { user } = authManager.getState();
+    // Wait for SilentSignIn to finish before rendering <GoogleLogin>.
+    // GoogleLogin internally calls google.accounts.id.initialize() without
+    // auto_select, which would otherwise overwrite SilentSignIn's
+    // auto_select=true configuration and prevent silent re-authentication.
+    const waitingForSilentSignIn = !authManager.silentSignInSettled;
 
     useEffect(() => {
         if (!map) return;
@@ -33,7 +38,7 @@ export function LoginButton({ map }: LoginButtonProps) {
         }
     }, [map, user]);
 
-    if (!container || user) return null;
+    if (!container || user || waitingForSilentSignIn) return null;
 
     return createPortal(
         <GoogleLogin


### PR DESCRIPTION
## Summary
This PR prevents GoogleLogin from rendering until SilentSignIn has completed its authentication attempt. This ensures that GoogleLogin's `google.accounts.id.initialize()` call doesn't overwrite SilentSignIn's `auto_select=true` configuration before the One Tap prompt can act on it.

## Key Changes

- **AuthManager enhancements**:
  - Added `silentSignInSettled` flag to track when SilentSignIn has finished (success, failure, or skipped)
  - Added `markSilentSignInSettled()` method to mark the silent sign-in attempt as complete
  - Added `getRevision()` method to provide a version counter for detecting state changes
  - Modified listener signature to pass no arguments; subscribers now use `getRevision()` to detect changes
  - Automatically mark silent sign-in as settled when there's no previous session (no need to attempt)

- **SilentSignIn component**:
  - Now calls `markSilentSignInSettled()` on successful credential response
  - Handles `onError` callback to mark settled on authentication errors
  - Handles `promptMomentNotification` callback to mark settled when the One Tap prompt is not displayed, skipped, or dismissed
  - Added comprehensive documentation explaining the coordination with LoginButton

- **LoginButton component**:
  - Added `waitingForSilentSignIn` check to delay rendering until `silentSignInSettled` is true
  - Prevents GoogleLogin from initializing while SilentSignIn is in flight

- **auth-context hook**:
  - Updated `useSyncExternalStore` to use `getRevision()` as the snapshot instead of full state
  - This allows subscribers to detect changes to any observable field, not just user state

- **Type definitions**:
  - Added `PromptMomentNotification` interface for One Tap prompt notifications
  - Extended `OneTapOptions` interface with `onError` and `promptMomentNotification` callbacks

## Implementation Details

The solution uses a coordination pattern where SilentSignIn notifies AuthManager when its attempt has settled (via any of three paths: success, error, or prompt-moment notification). LoginButton then waits for this flag before rendering GoogleLogin, ensuring the Google SDK initialization doesn't interfere with the One Tap auto-select behavior.

The revision counter pattern allows the subscription system to work with any observable field change, not just user authentication state, making the system more flexible for future additions.

https://claude.ai/code/session_017XLFbmHarELU8c7RrzvoK3