### PR TITLE
Extract station master data utilities into station.ts

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAuthManager } from '../auth/auth-context';
-import { reconcileVisits } from '../reconcile-visits';
+import { fetchStations, reconcileVisits } from '../station';
 import { createStorage, type Storage } from '../storage';
 import { StationsGeoJSON } from '../types/geojson';
 import { ShareButton } from './ShareButton';
@@ -40,16 +40,9 @@ export function RoadStationMap() {
 
     // Fetch stations data once
     useEffect(() => {
-        const fetchStations = async () => {
-            try {
-                const response = await fetch('../data/stations.geojson');
-                const data = await response.json();
-                setStations(data);
-            } catch (error) {
-                console.error('Error fetching stations:', error);
-            }
-        };
-        fetchStations();
+        fetchStations()
+            .then(setStations)
+            .catch((error) => console.error('Error fetching stations:', error));
     }, []);
 
     // Build the Storage whenever the auth state changes. RemoteStorage hydrates

--- a/src/frontend/station.test.ts
+++ b/src/frontend/station.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reconcileVisits } from './reconcile-visits';
+import { reconcileVisits } from './station';
 import { MemoryStorage } from './storage';
 import { createMockStations } from '../test-utils/test-utils';
 

--- a/src/frontend/station.ts
+++ b/src/frontend/station.ts
@@ -1,9 +1,11 @@
 import type { Storage } from './storage';
 import { StationsGeoJSON } from './types/geojson';
 
-/**
- * Drop stored visit entries whose station no longer exists in the GeoJSON.
- */
+export async function fetchStations(): Promise<StationsGeoJSON> {
+    const response = await fetch('../data/stations.geojson');
+    return response.json();
+}
+
 export function reconcileVisits(storage: Storage, stations: StationsGeoJSON): void {
     const validStationIds = new Set(stations.features.map(feature => feature.properties.stationId));
     storage.listItems().forEach(stationId => {


### PR DESCRIPTION
## Summary

- `fetchStations` を `RoadStationMap` のインライン定義から切り出し
- `reconcileVisits` とともに `station.ts` に統合（どちらも駅マスターデータを扱う処理）
- `reconcile-visits.ts` / `reconcile-visits.test.ts` を削除し、`station.ts` / `station.test.ts` に統合

## Test plan

- [ ] `npm test` で station.test.ts の全テストがパスすることを確認
- [ ] `npm run typecheck` がエラーなしで完了することを確認
- [ ] `npm run lint` がエラーなしで完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)