### PR TITLE
Remove unused authState parameter from createStorage

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -62,10 +62,7 @@ export function RoadStationMap() {
         });
         setLoadError(null);
 
-        createStorage({
-            authState: auth,
-            getIdToken: () => authManager.getState().idToken,
-        })
+        createStorage({ getIdToken: () => authManager.getState().idToken })
             .then((newStorage) => {
                 if (cancelled) return;
                 setStorage(newStorage);

--- a/src/frontend/storage/factory.test.ts
+++ b/src/frontend/storage/factory.test.ts
@@ -6,12 +6,9 @@ import { API_BASE_URL } from '../config';
 import { createStorage } from './factory';
 import { MemoryStorage } from './memory-storage';
 import { RemoteStorage } from './remote-storage';
-import type { AuthState } from '@shared/auth-types';
 
 describe('createStorage', () => {
     let originalLocation: Location;
-    const guestAuth: AuthState = { user: null, idToken: null };
-    const signedInAuth: AuthState = { user: { sub: 'user-1' }, idToken: 'token-abc' };
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -27,10 +24,7 @@ describe('createStorage', () => {
     });
 
     it('returns an empty MemoryStorage for guests', async () => {
-        const storage = await createStorage({
-            authState: guestAuth,
-            getIdToken: () => null,
-        });
+        const storage = await createStorage({ getIdToken: () => null });
         expect(storage).toBeInstanceOf(MemoryStorage);
         expect(storage.listItems()).toEqual([]);
     });
@@ -54,10 +48,7 @@ describe('createStorage', () => {
         );
 
         try {
-            const storage = await createStorage({
-                authState: signedInAuth,
-                getIdToken: () => 'token-abc',
-            });
+            const storage = await createStorage({ getIdToken: () => 'token-abc' });
 
             expect(storage).toBeInstanceOf(MemoryStorage);
             expect(storage.getItem('111')).toBe('1');
@@ -82,10 +73,7 @@ describe('createStorage', () => {
         );
 
         try {
-            const storage = await createStorage({
-                authState: signedInAuth,
-                getIdToken: () => 'token-abc',
-            });
+            const storage = await createStorage({ getIdToken: () => 'token-abc' });
 
             expect(storage).toBeInstanceOf(RemoteStorage);
             expect(storage.getItem('111')).toBe('2');

--- a/src/frontend/storage/factory.ts
+++ b/src/frontend/storage/factory.ts
@@ -1,5 +1,4 @@
 import queryString from 'query-string';
-import type { AuthState } from '@shared/auth-types';
 import { MemoryStorage } from './memory-storage';
 import { RemoteStorage } from './remote-storage';
 import { SharesApiClient } from './shares-api-client';
@@ -7,7 +6,6 @@ import { Storage } from './types';
 import { VisitsApiClient } from './visits-api-client';
 
 export interface CreateStorageOptions {
-    authState: AuthState;
     getIdToken: () => string | null;
 }
 
@@ -31,7 +29,7 @@ export async function createStorage(options: CreateStorageOptions): Promise<Stor
         return new MemoryStorage(entries);
     }
 
-    if (options.authState.idToken) {
+    if (options.getIdToken()) {
         const client = new VisitsApiClient({ getIdToken: options.getIdToken });
         return RemoteStorage.create({ client });
     }


### PR DESCRIPTION
## Summary
Removed the unused `authState` parameter from the `createStorage` function and its call sites. The authentication state is now determined solely through the `getIdToken` callback, simplifying the API.

## Key Changes
- Removed `authState: AuthState` parameter from `CreateStorageOptions` interface
- Removed the `AuthState` type import from factory.ts
- Updated the authentication check logic to use `options.getIdToken()` directly instead of `options.authState.idToken`
- Removed `authState` arguments from all `createStorage()` calls in tests and components
- Removed test fixture constants (`guestAuth` and `signedInAuth`) that are no longer needed

## Implementation Details
The change simplifies the storage factory by relying on the `getIdToken` callback as the single source of truth for authentication state. This reduces coupling and makes the API more straightforward - callers only need to provide a way to retrieve the ID token, rather than passing both the auth state object and a token getter function.

https://claude.ai/code/session_01NXA8oTDvTSikjUYQTiC1tp