### PR TITLE
Use setLoadError instead of console.error for fetch failures

### DIFF
--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -42,7 +42,7 @@ export function RoadStationMap() {
     useEffect(() => {
         fetchStations()
             .then(setStations)
-            .catch((error) => console.error('Error fetching stations:', error));
+            .catch((error) => setLoadError(error instanceof Error ? error.message : String(error)));
     }, []);
 
     // Build the Storage whenever the auth state changes. RemoteStorage hydrates
@@ -62,7 +62,6 @@ export function RoadStationMap() {
             })
             .catch((error) => {
                 if (cancelled) return;
-                console.error('Failed to create storage:', error);
                 setLoadError(error instanceof Error ? error.message : String(error));
             });
 


### PR DESCRIPTION
## Summary

- `fetchStations` 失敗時に `console.error` ではなく `setLoadError` を使用するよう変更
- `createStorage` 失敗時の冗長な `console.error` を削除（`setLoadError` で UI にエラーが表示されるため）

## Test plan

- [ ] `npm run typecheck` がエラーなしで完了することを確認
- [ ] `npm run lint` がエラーなしで完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)