### PR TITLE
Add path alias for test utilities

### DIFF
--- a/src/frontend/components/InfoWindow.test.tsx
+++ b/src/frontend/components/InfoWindow.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { InfoWindow } from './InfoWindow';
-import { createMockFeature } from '../../test-utils/test-utils';
+import { createMockFeature } from '@test-utils/test-utils';
 
 // Mock Google Maps API
 const mockInfoWindow = {

--- a/src/frontend/components/LoginButton.test.tsx
+++ b/src/frontend/components/LoginButton.test.tsx
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider } from '../auth/auth-context';
 import { AuthManager, ID_TOKEN_STORAGE_KEY } from '../auth/auth-manager';
 import { GOOGLE_CLIENT_ID } from '../config';
-import { createMockMap, setupGoogleMapsMock } from '../../test-utils/test-utils';
+import { createMockMap, setupGoogleMapsMock } from '@test-utils/test-utils';
 
 let lastGoogleLoginProps: { onSuccess?: (response: { credential?: string }) => void } | null = null;
 

--- a/src/frontend/components/Markers.test.tsx
+++ b/src/frontend/components/Markers.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { Markers } from './Markers';
-import { createMockFeature, createMockStations } from '../../test-utils/test-utils';
+import { createMockFeature, createMockStations } from '@test-utils/test-utils';
 import { MemoryStorage } from '../storage/memory-storage';
 
 const createMockMapData = () => {

--- a/src/frontend/components/ShareButton.test.tsx
+++ b/src/frontend/components/ShareButton.test.tsx
@@ -4,7 +4,7 @@
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthState } from '@shared/auth-types';
-import { createMockMap } from '../../test-utils/test-utils';
+import { createMockMap } from '@test-utils/test-utils';
 import { ShareButton } from './ShareButton';
 
 vi.mock('clipboard', () => ({

--- a/src/frontend/components/StationCounter.test.tsx
+++ b/src/frontend/components/StationCounter.test.tsx
@@ -9,7 +9,7 @@ import {
     createMockStations,
     createMockMap,
     setupGoogleMapsMock,
-} from '../../test-utils/test-utils';
+} from '@test-utils/test-utils';
 
 const getCounts = (element: HTMLElement): number[] =>
     Array.from(element.querySelectorAll('.station-counter-style span')).map((span) =>

--- a/src/frontend/station.test.ts
+++ b/src/frontend/station.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { reconcileVisits } from './station';
 import { MemoryStorage } from './storage';
-import { createMockStations } from '../test-utils/test-utils';
+import { createMockStations } from '@test-utils/test-utils';
 
 describe('reconcileVisits', () => {
     it('removes stored entries for stations not present in the GeoJSON', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@shared/*": ["./src/shared/*"]
+      "@shared/*": ["./src/shared/*"],
+      "@test-utils/*": ["./src/test-utils/*"]
     },
     "types": ["node", "@types/google.maps", "react", "react-dom"]
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@shared': path.resolve(__dirname, 'src/shared'),
+      '@test-utils': path.resolve(__dirname, 'src/test-utils'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
This PR introduces a TypeScript path alias for test utilities to improve import ergonomics and reduce relative path complexity in test files.

## Key Changes
- Added `@test-utils` path alias in `tsconfig.json` pointing to `./src/test-utils/*`
- Added corresponding alias configuration in `vitest.config.ts`
- Updated all test file imports to use the new `@test-utils` alias instead of relative paths (`../../test-utils/test-utils`)

## Files Modified
- **tsconfig.json**: Added `@test-utils/*` path mapping
- **vitest.config.ts**: Added `@test-utils` alias resolver
- **Test files**: Updated imports in 6 test files:
  - `src/frontend/components/InfoWindow.test.tsx`
  - `src/frontend/components/LoginButton.test.tsx`
  - `src/frontend/components/Markers.test.tsx`
  - `src/frontend/components/ShareButton.test.tsx`
  - `src/frontend/components/StationCounter.test.tsx`
  - `src/frontend/station.test.ts`

## Benefits
- Cleaner, more maintainable import statements in test files
- Consistent with existing `@shared` alias pattern
- Reduces cognitive load when reading test imports
- Makes test utilities feel like a first-class module in the project

https://claude.ai/code/session_0116XhBs1YSrJLKUWM2M1dpv