### PR TITLE
Add session token refresh mechanism with visibility-based polling

### DIFF
--- a/src/frontend/auth/auth-manager.test.ts
+++ b/src/frontend/auth/auth-manager.test.ts
@@ -3,7 +3,7 @@
  * @vitest-environment-options { "url": "http://localhost" }
  */
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
-import { buildSessionToken, jsonResponse } from '@test-utils/test-utils';
+import { buildSessionToken, emptyResponse, jsonResponse } from '@test-utils/test-utils';
 import { API_BASE_URL } from '../config';
 import { AuthManager, AuthManagerError, SESSION_TOKEN_STORAGE_KEY } from './auth-manager';
 
@@ -159,6 +159,92 @@ describe('AuthManager', () => {
 
         it('exposes a typed error class', () => {
             expect(new AuthManagerError('boom').name).toBe('AuthManagerError');
+        });
+    });
+
+    describe('refreshSession', () => {
+        let fetchMock: MockInstance<typeof fetch>;
+
+        beforeEach(() => {
+            fetchMock = vi.spyOn(globalThis, 'fetch');
+        });
+
+        afterEach(() => {
+            fetchMock.mockRestore();
+        });
+
+        it('does nothing when no session token is stored', async () => {
+            const manager = new AuthManager();
+
+            await manager.refreshSession();
+
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('sends the current session token as a bearer credential', async () => {
+            const token = buildSessionToken({ sub: 'user-1' });
+            localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+            fetchMock.mockResolvedValueOnce(emptyResponse(204));
+
+            const manager = new AuthManager();
+            await manager.refreshSession();
+
+            expect(fetchMock).toHaveBeenCalledWith(
+                `${API_BASE_URL}/sessions/refresh`,
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
+                })
+            );
+        });
+
+        it('keeps the existing token when the backend replies 204', async () => {
+            const token = buildSessionToken({ sub: 'user-1' });
+            localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+            fetchMock.mockResolvedValueOnce(emptyResponse(204));
+
+            const manager = new AuthManager();
+            await manager.refreshSession();
+
+            expect(manager.getState().sessionToken).toBe(token);
+        });
+
+        it('replaces the token when the backend issues a fresh one', async () => {
+            const oldToken = buildSessionToken({ sub: 'user-1', exp: 2000000000 });
+            localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, oldToken);
+            const newToken = buildSessionToken({ sub: 'user-1', exp: 2999999999 });
+            fetchMock.mockResolvedValueOnce(
+                jsonResponse({ sessionToken: newToken, expiresAt: 2999999999 })
+            );
+
+            const manager = new AuthManager();
+            await manager.refreshSession();
+
+            expect(manager.getState().sessionToken).toBe(newToken);
+            expect(localStorage.getItem(SESSION_TOKEN_STORAGE_KEY)).toBe(newToken);
+        });
+
+        it('clears the session when the backend replies 401', async () => {
+            const token = buildSessionToken({ sub: 'user-1' });
+            localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+            fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'unauthorized' }, 401));
+
+            const manager = new AuthManager();
+            await manager.refreshSession();
+
+            expect(manager.getState()).toEqual({ user: null, sessionToken: null });
+            expect(localStorage.getItem(SESSION_TOKEN_STORAGE_KEY)).toBeNull();
+        });
+
+        it('keeps the existing token when fetch throws (network error)', async () => {
+            const token = buildSessionToken({ sub: 'user-1' });
+            localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+            fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+            const manager = new AuthManager();
+            await manager.refreshSession();
+
+            expect(manager.getState().sessionToken).toBe(token);
         });
     });
 });

--- a/src/frontend/auth/auth-manager.ts
+++ b/src/frontend/auth/auth-manager.ts
@@ -1,4 +1,8 @@
-import type { CreateSessionRequest, CreateSessionResponse } from '@shared/api-types';
+import type {
+    CreateSessionRequest,
+    CreateSessionResponse,
+    RefreshSessionResponse,
+} from '@shared/api-types';
 import type { AuthState } from '@shared/auth-types';
 import { API_BASE_URL } from '../config';
 import { decodeSessionToken, isSessionTokenExpired } from './session-token';
@@ -60,6 +64,38 @@ export class AuthManager {
         }
         localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
         this.setState({ user: { sub: claims.sub }, sessionToken: token });
+    }
+
+    // Ask the backend whether the current session token should be rotated.
+    // The endpoint replies 204 when the token still has plenty of life left,
+    // 200 with a fresh token when it is approaching expiry, and 401 when the
+    // current token is no longer valid. Network errors are swallowed so a
+    // hiccup never logs the user out.
+    async refreshSession(): Promise<void> {
+        const token = this.state.sessionToken;
+        if (!token) return;
+
+        let response: Response;
+        try {
+            response = await fetch(`${API_BASE_URL}/sessions/refresh`, {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${token}` },
+            });
+        } catch {
+            return;
+        }
+
+        if (response.status === 204) return;
+
+        if (response.status === 401) {
+            this.clearSession();
+            return;
+        }
+
+        if (!response.ok) return;
+
+        const json = (await response.json()) as RefreshSessionResponse;
+        this.updateSessionToken(json.sessionToken);
     }
 
     // Wipe the local session. Called on explicit logout or when the API

--- a/src/frontend/auth/use-session-refresh.test.tsx
+++ b/src/frontend/auth/use-session-refresh.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options { "url": "http://localhost" }
+ */
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthManager } from './auth-manager';
+import { useSessionRefresh } from './use-session-refresh';
+
+function Harness({ manager }: { manager: AuthManager }) {
+    useSessionRefresh(manager);
+    return null;
+}
+
+describe('useSessionRefresh', () => {
+    let manager: AuthManager;
+    let refreshSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        localStorage.clear();
+        manager = new AuthManager();
+        refreshSpy = vi.spyOn(manager, 'refreshSession').mockResolvedValue();
+    });
+
+    afterEach(() => {
+        refreshSpy.mockRestore();
+    });
+
+    it('refreshes once on mount', () => {
+        render(<Harness manager={manager} />);
+
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes when the page becomes visible', () => {
+        render(<Harness manager={manager} />);
+        refreshSpy.mockClear();
+
+        act(() => {
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                value: 'visible',
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh when the page is hidden', () => {
+        render(<Harness manager={manager} />);
+        refreshSpy.mockClear();
+
+        act(() => {
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                value: 'hidden',
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it('removes the listener on unmount', () => {
+        const { unmount } = render(<Harness manager={manager} />);
+        unmount();
+        refreshSpy.mockClear();
+
+        act(() => {
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                value: 'visible',
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/frontend/auth/use-session-refresh.ts
+++ b/src/frontend/auth/use-session-refresh.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import type { AuthManager } from './auth-manager';
+
+// Refresh the backend-issued session token on mount and whenever the tab
+// becomes visible again. The browser fires `visibilitychange` for tab
+// switches, window minimise/restore, and (on most platforms) when the user
+// returns from another application — covering the "browser became active"
+// case without a separate `focus` listener.
+export function useSessionRefresh(authManager: AuthManager): void {
+    useEffect(() => {
+        void authManager.refreshSession();
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                void authManager.refreshSession();
+            }
+        };
+
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    }, [authManager]);
+}

--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAuthManager } from '../auth/auth-context';
+import { useSessionRefresh } from '../auth/use-session-refresh';
 import { fetchStations, reconcileVisits } from '../station';
 import { createStorage, type Storage } from '../storage';
 import { StationsGeoJSON } from '../types/geojson';
@@ -18,6 +19,7 @@ const getCurrentPosition = (): Promise<GeolocationPosition> => {
 export function RoadStationMap() {
     const authManager = useAuthManager();
     const auth = authManager.getState();
+    useSessionRefresh(authManager);
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const [map, setMap] = useState<google.maps.Map | null>(null);
     const [feature, setFeature] = useState<google.maps.Data.Feature | null>(null);


### PR DESCRIPTION
## Summary
Implements automatic session token refresh functionality to keep user sessions alive by periodically checking with the backend and rotating tokens when necessary. The refresh is triggered on component mount and whenever the browser tab becomes visible.

## Key Changes
- **AuthManager.refreshSession()**: New method that sends the current session token to the backend's `/sessions/refresh` endpoint
  - Returns 204 if token is still valid (no action needed)
  - Returns 200 with a new token if rotation is needed
  - Returns 401 if session is invalid (clears local session)
  - Gracefully handles network errors without logging out the user

- **useSessionRefresh hook**: New React hook that manages session refresh lifecycle
  - Refreshes session on component mount
  - Listens to `visibilitychange` events to refresh when tab becomes visible
  - Properly cleans up event listeners on unmount
  - Covers tab switches, window minimize/restore, and app switching scenarios

- **RoadStationMap integration**: Integrated the `useSessionRefresh` hook into the main map component to enable automatic session management

- **Test coverage**: Comprehensive test suites for both the new `refreshSession()` method and `useSessionRefresh` hook, covering all response scenarios and edge cases

## Implementation Details
- Network errors are intentionally swallowed to prevent accidental logouts due to temporary connectivity issues
- The visibility API is used instead of focus events for more reliable detection of when the browser becomes active
- Token updates are persisted to localStorage and reflected in the AuthManager state

https://claude.ai/code/session_019cpDtodPWhEszdfgMRY5JN