### PR TITLE
ci: Replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
 
       - name: Approve a PR

--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
+          client-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
           private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -10,7 +10,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
 
       - name: Dependabot metadata

--- a/.github/workflows/update-station-data.yml
+++ b/.github/workflows/update-station-data.yml
@@ -16,7 +16,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ vars.STATION_UPDATE_APP_ID }}
+        client-id: ${{ vars.STATION_UPDATE_APP_ID }}
         private-key: ${{ secrets.STATION_UPDATE_PRIVATE_KEY }}
 
     - name: Checkout repository


### PR DESCRIPTION
## Summary

- Replace deprecated `app-id` input with `client-id` in `actions/create-github-app-token@v3`
- Since v3.1.0, `app-id` has been deprecated in favor of `client-id`
- This change affects `auto-merge.yml`, `dependabot-auto-label.yml`, `biome-migrate.yml`, and `update-station-data.yml`