### PR TITLE
ci: use pull-requests:write for dependabot auto-label workflow

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
-          permission-issues: write
+          permission-pull-requests: write
 
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary
The `PR_AUTO_MERGER` GitHub App installation does not grant `Issues: write`, so token creation in `dependabot-auto-label.yml` fails with `The permissions requested are not granted to this installation.` Switch the requested permission from `issues: write` to `pull-requests: write`, which the App already has and is sufficient for labeling PRs.

Skeleton update: tk0miya/skills#25

## Test plan
- [ ] Trigger by rebasing a Dependabot PR and confirm `add-auto-merge-label` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)