### PR TITLE
ci: scope deploy workflow permissions to the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -48,6 +46,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
zizmor's `excessive-permissions` audit flagged the deploy workflow because `pages: write` and `id-token: write` were granted at the workflow level, exposing them to the `build` job that doesn't need them.

Move those two permissions to the `deploy` job (which uses `actions/deploy-pages`), and leave the workflow-level permissions as `contents: read` only.

## Test plan
- [ ] Confirm zizmor no longer reports `excessive-permissions` against `deploy.yml`.
- [ ] Confirm the next deploy run still succeeds (deploy job retains its required permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)