### PR TITLE
chore: track .claude/ and adopt the shared dev-workflow hooks

### DIFF
--- a/.claude/hooks/self-review.sh
+++ b/.claude/hooks/self-review.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# PreToolUse hook: review code before `git commit`.
+#
+# Fires before a Bash `git commit` command and blocks the first commit attempt
+# for a given change-set, asking Claude to review the code before committing.
+# The review uses the `self-review` skill when available, and falls back to the
+# bundled `code-review` skill otherwise — so the hook works even in projects
+# that don't ship the custom self-review skill.
+#
+# A per-change-set marker (keyed by a hash of the diff, stored under .git/)
+# prevents an infinite block loop: once a change-set has been surfaced for
+# review, the matching commit is allowed through. If the review leads to fixes,
+# the diff changes, so the new state is reviewed once more before it commits.
+#
+
+set -euo pipefail
+
+# Read JSON input from stdin
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only gate the Bash tool running a git commit.
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+# Match `git commit`, or `git -C <path> commit`.
+commit_re='git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?commit'
+if [[ ! "$command" =~ $commit_re ]]; then
+  exit 0
+fi
+
+# If the command targets a specific repo via `git -C <path>`, operate there too.
+work_dir="."
+if [[ "$command" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  work_dir="${BASH_REMATCH[1]}"
+fi
+
+# Not a git repo → nothing to do.
+git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null || true)
+if [[ -z "$git_dir" ]]; then
+  exit 0
+fi
+
+# Hash what will be committed. `git status --porcelain` is included so a commit
+# that only adds untracked files isn't mistaken for empty; `git diff HEAD` adds
+# tracked content. On the first commit there is no HEAD, so use the working state.
+if git -C "$work_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+  changeset=$(git -C "$work_dir" status --porcelain; git -C "$work_dir" diff HEAD)
+else
+  changeset=$(git -C "$work_dir" status --porcelain; git -C "$work_dir" diff; git -C "$work_dir" diff --cached)
+fi
+
+# Nothing to review (e.g. a message-only `--amend`) → let it proceed.
+if [[ -z "$changeset" ]]; then
+  exit 0
+fi
+
+hash=$(printf '%s' "$changeset" | git hash-object --stdin)
+state_file="$git_dir/self-review-reviewed"
+
+# Already surfaced for review → allow the commit.
+if [[ -f "$state_file" ]] && grep -qxF "$hash" "$state_file"; then
+  exit 0
+fi
+
+# Record this change-set and block once to force a review first.
+echo "$hash" >> "$state_file"
+
+review_prompt='SELF-REVIEW REQUIRED before committing. Review the changes that are
+about to be committed BEFORE running git commit again:
+
+- If the `self-review` skill is available, invoke it (Skill tool, skill "self-review").
+- Otherwise, run the bundled `/code-review` skill on the working diff.
+
+If the review finds issues, fix them and review again. Once it is clean, run the same
+git commit command again to proceed — it will be allowed through.'
+
+jq -n --arg reason "$review_prompt" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": $reason
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/self-review.sh",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ data/
 node_modules
 html/js/bundle.js
 
-# Claude Code settings
-.claude/
+# Claude Code personal settings (project settings under .claude/ are tracked)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Completes the sweep that landed across the other repositories (tk0miya/not_nilable#43 and friends). This one had been skipped throughout, because `.gitignore` excluded the entire `.claude/` directory — the shared Claude Code project settings were never under version control here, so nothing to update was ever visible.

## Changes

- **Narrow the ignore rule** from `.claude/` to `.claude/settings.local.json`, the personal-settings file that genuinely should stay out of the repository. Project settings under `.claude/` are now tracked, matching every other repository in the account.
- **Add `.claude/hooks/self-review.sh`** — the `setup-dev-workflow-hooks` PreToolUse hook. It reviews the changes about to be committed before `git commit` goes through, using the `self-review` skill when available and falling back to the bundled `/code-review` otherwise. A per-change-set marker under `.git/` keeps it from looping.
- **Add `.claude/settings.json`** — wires that hook in for the Bash tool.

## Verification

- Both new files are byte-identical to their skill templates: `self-review.sh` at blob SHA `a292e9d` with mode 100755, `settings.json` at `438a7bb`.
- `git status` after staging shows only the three intended paths; the local `.claude/.cc-writes/` scratch directory is not picked up.
- No workflow files are touched, so there are no action SHAs to verify.

No test cases were added: the change is tooling configuration with no effect on the application.

## Not applicable here

The Ruby-specific parts of the sweep (`rbs:regenerate`, `rubocop.yml` ordering, `release.yml` permissions) do not apply, and the `RemoteTrigger` permission rule that the other repositories had to drop was never committed here — so this lands the current state directly, without that entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)