### PR TITLE
Allow renaming planned stations via CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ data/         生成データ（CSV / GeoJSON）
 - **`doGet` / `doPost` で分ける**: verb 分岐は Apps Script が提供しているので、`doPost({ action })` のような分岐を自前で作らない。読み取りは副作用がなく冪等で、`/exec` をブラウザで開けばデプロイの確認もできる
 - **日付の正規化**: `doGet` は Date セルを `yyyy-MM-dd` に揃えて返す。セルの表示書式に API の応答が左右されないようにするため。Date 以外は素通しするので、`lat` / `lng` は JSON の数値、空セルは空文字になる
 - **列の解決**: 列位置はハードコードせずヘッダ行（`name` / `pref` / `city` / `status` / `date` / `lat` / `lng` / `memo`）から引く。API のフィールド名は公開 CSV のヘッダ名と一致する
-- **エントリーの特定**: `name` 列の完全一致（該当なしなら `{ updated: false, row: null }`）
+- **エントリーの特定**: `name` 列の完全一致（重複していれば最初に見つかった行、該当なしなら `{ updated: false, row: null }`）
 - **`Content-Type: text/plain`**: CORS プリフライトを避けるため（Apps Script は preflight に応答しない）
 - **公開範囲**: `ANYONE_ANONYMOUS`。個人利用前提の割り切りなので URL は共有しない
 - **Biome**: `gas/` は GAS のグローバルスコープ前提（`export` を持たない）のため `biome.json` の `overrides` で `noUnusedVariables` を無効化
@@ -150,7 +150,7 @@ POST https://script.google.com/macros/s/xxx/exec   (Content-Type: text/plain)
 → { "updated": true, "row": 12 }
 ```
 
-`values` に含めたフィールドのみ上書きし、含めなかったフィールドは現在値を保つ。
+`values` に含めたフィールドのみ上書きし、含めなかったフィールドは現在値を保つ。`values.name` を含めるとエントリーを改名する。
 
 ### 開発計画データ CLI（`npm run plan:*`）
 
@@ -159,14 +159,15 @@ POST https://script.google.com/macros/s/xxx/exec   (Content-Type: text/plain)
 ```
 npm run --silent plan:list | jq -r '.[] | select(.status == "計画中") | .name'
 npm run plan:update -- "道の駅◯◯" --status=開業 --date=2026-04-01
+npm run plan:update -- "道の駅◯◯（仮称）" --name=道の駅◯◯
 ```
 
 - **`list` は JSON を出すだけ**で絞り込み・整形のオプションを持たない。`jq` のほうが上手くやれるため
 - **`npm run` のバナーは stdout に出る**ので、`jq` に流すときは `--silent` が要る
 - **script 名は `plan:list` / `plan:update`**: `db:migrate` / `gas:push` と同じ `<名前空間>:<動詞>` 形式に揃える。サブコマンドを script 側に埋めてあるので、`list` は `--` なしで `jq` に流せる
-- **`update` は送信前に検証する**: 更新可能フィールド（`status` / `date` / `lat` / `lng` / `memo`）以外のフラグ、範囲外の `status`、非数値の座標、フィールド無指定を弾く。GAS 側にエラー処理がなく、不正入力は HTML のエラーページとして返るため
+- **`update` は送信前に検証する**: 更新可能フィールド（`name` / `status` / `date` / `lat` / `lng` / `memo`）以外のフラグ、範囲外の `status`、非数値の座標、空の `name`、フィールド無指定を弾く。GAS 側にエラー処理がなく、不正入力は HTML のエラーページとして返るため
 - **`date` は検証しない**: シートは判明している粒度をそのまま記録するため、`2026-04-01` / `2026-04` / `2026` / `2026夏` のいずれもありうる。単一のパターンに押し込められない
-- **`name` / `pref` / `city` は更新対象外**: エントリーを同定・配置する列で、進捗を表す列ではない（`name` は一致キー、`city` は地図の市区町村代表点フォールバックの引き当てに使う）。修正は文脈の見えるスプレッドシート上で行う
+- **`pref` / `city` は更新対象外**: エントリーを配置する列で、進捗を表す列ではない（`city` は地図の市区町村代表点フォールバックの引き当てに使う）。修正は文脈の見えるスプレッドシート上で行う
 - **`PLAN_API_URL`**: `/exec` の URL。`.env`（gitignore 済み、`.env.example` を参照）に置き、`dotenv` で読む
 
 ### ビルド・デプロイ

--- a/src/scripts/plan.test.ts
+++ b/src/scripts/plan.test.ts
@@ -46,7 +46,24 @@ describe('buildValues', () => {
         expect(() => buildValues({ nmae: '道の駅あ' })).toThrow('Unknown field: --nmae');
     });
 
-    it.each(['name', 'pref', 'city'])('rejects %s, which identifies an entry rather than describing it', (field) => {
+    it('passes through a rename', () => {
+        expect(buildValues({ name: '道の駅い' })).toEqual({ name: '道の駅い' });
+    });
+
+    it('trims every value, since no column of the sheet carries padding', () => {
+        expect(buildValues({ name: ' 道の駅い ', status: ' 開業 ', lat: ' 36.1 ' })).toEqual({
+            name: '道の駅い',
+            status: '開業',
+            lat: '36.1',
+        });
+    });
+
+    it('rejects an empty name, which no entry could be found by', () => {
+        expect(() => buildValues({ name: '' })).toThrow('Invalid --name');
+        expect(() => buildValues({ name: '  ' })).toThrow('Invalid --name');
+    });
+
+    it.each(['pref', 'city'])('rejects %s, which places an entry rather than describing it', (field) => {
         expect(() => buildValues({ [field]: '福井県' })).toThrow(`Unknown field: --${field}`);
     });
 

--- a/src/scripts/plan.ts
+++ b/src/scripts/plan.ts
@@ -18,19 +18,20 @@ import { list, update } from '../lib/plan-api.js';
 // duplication is cheaper than a scripts -> frontend dependency.
 const STATUSES = ['開業', '登録済み', '計画中', '中止'];
 
-// Columns update accepts, matching the sheet's header labels. `name`, `pref`
-// and `city` are left out: they identify and place an entry rather than
-// describe its progress, and `city` also drives the map's fallback to the
-// municipality's representative point. Correcting them is done in the
-// spreadsheet, where the change is visible in context.
-const UPDATABLE_FIELDS = ['status', 'date', 'lat', 'lng', 'memo'];
+// Columns update accepts, matching the sheet's header labels. `pref` and `city`
+// are left out: they place an entry rather than describe its progress, and
+// `city` also drives the map's fallback to the municipality's representative
+// point. Correcting them is done in the spreadsheet, where the change is
+// visible in context.
+const UPDATABLE_FIELDS = ['name', 'status', 'date', 'lat', 'lng', 'memo'];
 
 const USAGE = `Read and update the roadside-station development-plan spreadsheet.
 
 Usage:
   npm run --silent plan:list
-  npm run plan:update -- "<name>" [--status=<status>] [--date=<text>]
-                                  [--lat=<number>] [--lng=<number>] [--memo=<text>]
+  npm run plan:update -- "<name>" [--name=<new name>] [--status=<status>]
+                                  [--date=<text>] [--lat=<number>]
+                                  [--lng=<number>] [--memo=<text>]
 
 Commands:
   list     Print every entry as JSON. Filter it with jq:
@@ -39,8 +40,9 @@ Commands:
            fails to parse the output.
   update   Overwrite the given fields on the entry whose name matches exactly.
            Fields left out keep their current content; pass an empty value
-           (e.g. --date=) to clear a field. name, pref and city are not
-           writable here -- correct them in the spreadsheet.
+           (e.g. --date=) to clear a field -- except --name, which every entry
+           is identified by. pref and city are not writable here -- correct
+           them in the spreadsheet.
 
 Status values: ${STATUSES.join(', ')}
 Date: free text, as precise as is known -- 2026-04-01, 2026-04, 2026, 2026夏
@@ -93,7 +95,11 @@ export function parseArgs(args: string[]): ParsedArgs {
 // unknown column or a malformed value comes back as an HTML error page rather
 // than a useful message -- cheaper to catch it before sending.
 function validateField(field: string, value: string): void {
-    const trimmed = value.trim();
+    // `name` is how every entry is identified, so unlike the other fields it
+    // cannot be cleared.
+    if (field === 'name' && value === '') {
+        throw new Error('Invalid --name: the new name must not be empty.');
+    }
 
     if (field === 'status' && !STATUSES.includes(value)) {
         throw new Error(`Invalid --status: ${value}. Valid values: ${STATUSES.join(', ')}`);
@@ -103,7 +109,7 @@ function validateField(field: string, value: string): void {
     // which may be a full date, a year, a year and month, or a season
     // ("2026夏"). No single pattern covers that.
 
-    if ((field === 'lat' || field === 'lng') && trimmed !== '' && Number.isNaN(Number(trimmed))) {
+    if ((field === 'lat' || field === 'lng') && value !== '' && Number.isNaN(Number(value))) {
         throw new Error(`Invalid --${field}: ${value}. Expected a number, or an empty value to clear it.`);
     }
 }
@@ -116,8 +122,11 @@ export function buildValues(flags: Record<string, string>): Record<string, strin
             const valid = UPDATABLE_FIELDS.map((f) => `--${f}`).join(', ');
             throw new Error(`Unknown field: --${field}. Valid fields: ${valid}`);
         }
-        validateField(field, value);
-        values[field] = value;
+        // No column of the sheet is meant to carry surrounding whitespace, so
+        // values are validated and written in their trimmed form.
+        const trimmed = value.trim();
+        validateField(field, trimmed);
+        values[field] = trimmed;
     }
 
     // The Apps Script happily reports updated: true for an empty `values`,


### PR DESCRIPTION
Enable the `plan:update` command to rename entries by adding `name` to the updatable fields. This allows tracking provisional-to-official name changes as progress, similar to status or date updates.

## Summary

Planned stations are often registered under provisional names and renamed once official names are settled. This change makes `name` an updatable field so the CLI can track these renames alongside other progress updates.

The Apps Script is unchanged: `updateEntry` already writes whatever columns `values` carries, so `name` needs no special support there.

## Key changes

- **CLI (`src/scripts/plan.ts`)**:
  - Added `name` to `UPDATABLE_FIELDS`
  - Updated usage documentation and help text to show `--name=` syntax, and to note that `--name` is the one field that cannot be cleared
  - Added validation in `validateField()` to reject empty names (since `name` is the lookup key)
  - Moved trimming from `validateField()` into `buildValues()` so every value is validated and written in its trimmed form -- previously a padded value passed validation and was then written with its padding

- **Tests (`src/scripts/plan.test.ts`)**:
  - `buildValues > passes through a rename` — `--name` is accepted as an updatable field and reaches the request body
  - `buildValues > trims every value, since no column of the sheet carries padding` — surrounding whitespace is stripped before validating and sending
  - `buildValues > rejects an empty name, which no entry could be found by` — `--name=` and a whitespace-only `--name` are rejected before sending
  - Updated the existing off-limits test to cover only `pref` and `city`, now that `name` is updatable

- **Documentation (`CLAUDE.md`)**:
  - Noted that `values.name` renames an entry, and that a duplicated name resolves to the first matching row
  - Added a rename example, and narrowed the off-limits note to `pref` / `city`

## Implementation notes

- **Validation stays on the CLI side**, as it does for every other field: the Apps Script has no error handling, so bad input has to be caught before sending.
- **Duplicate names are not checked.** That needs the sheet's own state, and a duplicate is as likely to come from editing the sheet by hand, so it is corrected there. A duplicated name resolves to the first matching row until then.

https://claude.ai/code/session_01X5oE1JkeEMVydHoKQi1KHu