### PR TITLE
Key a plan entry update on its name and prefecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,9 @@ data/         生成データ（CSV / GeoJSON）
 
 - **TypeScript ではなく JavaScript**: 個人利用の小さなスクリプトで、ビルド工程を挟まずそのまま GAS に反映することを優先
 - **`doGet` / `doPost` で分ける**: verb 分岐は Apps Script が提供しているので、`doPost({ action })` のような分岐を自前で作らない。読み取りは副作用がなく冪等で、`/exec` をブラウザで開けばデプロイの確認もできる
-- **日付の正規化**: `doGet` は Date セルを `yyyy-MM-dd` に揃えて返す。セルの表示書式に API の応答が左右されないようにするため。Date 以外は素通しするので、`lat` / `lng` は JSON の数値、空セルは空文字になる
+- **値の正規化**: `doGet` は Date セルを `yyyy-MM-dd` に揃え、文字列セルは前後の空白を落として返す。セルの表示書式や余分な空白に API の応答が左右されず、一覧で見た値をそのまま `update` の一致キーに使えるようにするため。数値は素通しするので `lat` / `lng` は JSON の数値、空セルは空文字になる
 - **列の解決**: 列位置はハードコードせずヘッダ行（`name` / `pref` / `city` / `status` / `date` / `lat` / `lng` / `memo`）から引く。API のフィールド名は公開 CSV のヘッダ名と一致する
-- **エントリーの特定**: `name` 列の完全一致（重複していれば最初に見つかった行、該当なしなら `{ updated: false, row: null }`）
+- **エントリーの特定**: `name` 列と `pref` 列の完全一致。`name` は一意ではない（「道の駅 川崎町」が福岡県と宮城県にある）ので、`pref` はキーの片割れとして必須にする。**一致が 1 件のときだけ書き込む** — 複数一致で先頭行を書くと取り違えに気づけないため
 - **`Content-Type: text/plain`**: CORS プリフライトを避けるため（Apps Script は preflight に応答しない）
 - **公開範囲**: `ANYONE_ANONYMOUS`。個人利用前提の割り切りなので URL は共有しない
 - **Biome**: `gas/` は GAS のグローバルスコープ前提（`export` を持たない）のため `biome.json` の `overrides` で `noUnusedVariables` を無効化
@@ -146,11 +146,11 @@ GET https://script.google.com/macros/s/xxx/exec
 → [{ "name": "道の駅◯◯", "pref": "福井県", "status": "計画中", "date": "", "lat": 36.1, ... }, ...]
 
 POST https://script.google.com/macros/s/xxx/exec   (Content-Type: text/plain)
-{ "name": "道の駅◯◯", "values": { "status": "開業", "date": "2026-04-01" } }
-→ { "updated": true, "row": 12 }
+{ "name": "道の駅◯◯", "pref": "福井県", "values": { "status": "開業", "date": "2026-04-01" } }
+→ { "updated": true, "row": 12, "matched": 1 }
 ```
 
-`values` に含めたフィールドのみ上書きし、含めなかったフィールドは現在値を保つ。`values.name` を含めるとエントリーを改名する。
+`name` と `pref` は両方必須。`values` に含めたフィールドのみ上書きし、含めなかったフィールドは現在値を保つ。`values.name` を含めるとエントリーを改名する。`matched` は一致件数で、1 件でなければ何も書かず `{ "updated": false, "row": null, "matched": <件数> }` を返す。
 
 ### 開発計画データ CLI（`npm run plan:*`）
 
@@ -158,16 +158,16 @@ POST https://script.google.com/macros/s/xxx/exec   (Content-Type: text/plain)
 
 ```
 npm run --silent plan:list | jq -r '.[] | select(.status == "計画中") | .name'
-npm run plan:update -- "道の駅◯◯" --status=開業 --date=2026-04-01
-npm run plan:update -- "道の駅◯◯（仮称）" --name=道の駅◯◯
+npm run plan:update -- "道の駅◯◯" 福井県 --status=開業 --date=2026-04-01
+npm run plan:update -- "道の駅◯◯（仮称）" 福井県 --name=道の駅◯◯
 ```
 
 - **`list` は JSON を出すだけ**で絞り込み・整形のオプションを持たない。`jq` のほうが上手くやれるため
 - **`npm run` のバナーは stdout に出る**ので、`jq` に流すときは `--silent` が要る
 - **script 名は `plan:list` / `plan:update`**: `db:migrate` / `gas:push` と同じ `<名前空間>:<動詞>` 形式に揃える。サブコマンドを script 側に埋めてあるので、`list` は `--` なしで `jq` に流せる
-- **`update` は送信前に検証する**: 更新可能フィールド（`name` / `status` / `date` / `lat` / `lng` / `memo`）以外のフラグ、範囲外の `status`、非数値の座標、空の `name`、フィールド無指定を弾く。GAS 側にエラー処理がなく、不正入力は HTML のエラーページとして返るため
+- **`update` は送信前に検証する**: 更新可能フィールド（`name` / `status` / `date` / `lat` / `lng` / `memo`）以外のフラグ、範囲外の `status`、非数値の座標、空の `name`、フィールド無指定、キー（名前・都道府県）の欠落や不正を弾く。GAS 側にエラー処理がなく、不正入力は HTML のエラーページとして返るため
 - **`date` は検証しない**: シートは判明している粒度をそのまま記録するため、`2026-04-01` / `2026-04` / `2026` / `2026夏` のいずれもありうる。単一のパターンに押し込められない
-- **`pref` / `city` は更新対象外**: エントリーを配置する列で、進捗を表す列ではない（`city` は地図の市区町村代表点フォールバックの引き当てに使う）。修正は文脈の見えるスプレッドシート上で行う
+- **`pref` / `city` は更新対象外**: エントリーを同定・配置する列で、進捗を表す列ではない（`city` は地図の市区町村代表点フォールバックの引き当てに使う）。修正は文脈の見えるスプレッドシート上で行う
 - **`PLAN_API_URL`**: `/exec` の URL。`.env`（gitignore 済み、`.env.example` を参照）に置き、`dotenv` で読む
 
 ### ビルド・デプロイ

--- a/gas/Code.js
+++ b/gas/Code.js
@@ -9,10 +9,12 @@
 //
 // POST updates one entry. Its body uses Content-Type: text/plain, so the
 // request stays a CORS simple request and Apps Script does not answer it with
-// a redirect to a preflight:
-//   { "name": "道の駅◯◯", "values": { "status": "開業", "date": "2026-04-01" } }
+// a redirect to a preflight. `name` and `pref` together identify the entry; see
+// plan.js for when a write happens at all:
+//   { "name": "道の駅◯◯", "pref": "福岡県",
+//     "values": { "status": "開業", "date": "2026-04-01" } }
 // Response:
-//   { "updated": true, "row": 12 }
+//   { "updated": true, "row": 12, "matched": 1 }
 
 function doGet() {
     return ContentService.createTextOutput(JSON.stringify(listEntries())).setMimeType(ContentService.MimeType.JSON);
@@ -20,6 +22,6 @@ function doGet() {
 
 function doPost(e) {
     const request = JSON.parse(e.postData.contents);
-    const result = updateEntry(request.name, request.values);
+    const result = updateEntry(request.name, request.pref, request.values);
     return ContentService.createTextOutput(JSON.stringify(result)).setMimeType(ContentService.MimeType.JSON);
 }

--- a/gas/plan.js
+++ b/gas/plan.js
@@ -4,85 +4,107 @@
 // the column layout is discovered from the header row instead of being
 // hard-coded: the field names accepted by the API are exactly the CSV headers
 // (name, pref, city, status, date, lat, lng, memo).
+//
+// The sheet is read in one place, readPlanSheet, which normalizes every value it
+// hands out, so what listEntries returns is what findRows matches on.
 
-// Header label of the column identifying an entry.
+// Header labels of the columns identifying an entry. A name is not unique on
+// its own -- 道の駅 川崎町 exists in both 福岡県 and 宮城県 -- so the prefecture
+// is the second half of the key.
 const NAME_FIELD = 'name';
+const PREF_FIELD = 'pref';
 
 // The plan sheet is the leftmost one, as in the published CSV.
 function getPlanSheet() {
     return SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
 }
 
-// Header label -> 1-based column index.
-function getColumnIndexes(sheet) {
-    const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    const indexes = {};
-    headers.forEach((header, index) => {
-        indexes[String(header).trim()] = index + 1;
-    });
-    return indexes;
-}
-
-// 1-based row number of the entry with the given name, or -1 when it is absent.
-function findRowByName(sheet, nameColumn, name) {
-    const lastRow = sheet.getLastRow();
-    if (lastRow < 2) {
-        return -1;
-    }
-
-    const names = sheet.getRange(2, nameColumn, lastRow - 1, 1).getValues();
-    const index = names.findIndex((row) => String(row[0]).trim() === name);
-    return index === -1 ? -1 : index + 2;
-}
-
-// Sheet cell value -> JSON-safe value. Date cells are normalized to yyyy-MM-dd
-// so the API's shape does not depend on how the column happens to be formatted.
-// Everything else is passed through, which keeps numeric columns (lat, lng)
-// numbers in the JSON and empty cells empty strings.
+// Sheet cell value -> JSON-safe value: a Date becomes yyyy-MM-dd, so the API's
+// shape does not depend on how the column happens to be formatted, and text is
+// trimmed. Everything else is passed through, which keeps numeric columns (lat,
+// lng) numbers in the JSON and empty cells empty strings.
 function toFieldValue(value) {
     if (value instanceof Date) {
         return Utilities.formatDate(value, 'Asia/Tokyo', 'yyyy-MM-dd');
     }
+    if (typeof value === 'string') {
+        return value.trim();
+    }
     return value;
 }
 
-// Every entry in the sheet, as objects keyed by the header labels. The whole
-// range is read in one call rather than row by row, as in findRowByName.
-function listEntries() {
+// Request value -> the form the sheet's text columns are read in, so the two can
+// be compared as they are. A missing key normalizes to the empty string.
+function toKeyValue(value) {
+    return String(value === undefined || value === null ? '' : value).trim();
+}
+
+// The sheet in one read: the sheet itself, to write back to; its header labels
+// in column order, which give a field its column (0-based here, 1-based in the
+// sheet); and every row below the header, where row N of the sheet is
+// rows[N - 2].
+function readPlanSheet() {
     const sheet = getPlanSheet();
     const lastRow = sheet.getLastRow();
-    if (lastRow < 2) {
-        return [];
+    if (lastRow < 1) {
+        return { sheet, fields: [], rows: [] };
     }
 
     const values = sheet.getRange(1, 1, lastRow, sheet.getLastColumn()).getValues();
-    const fields = values[0].map((header) => String(header).trim());
+    return {
+        sheet,
+        fields: values[0].map(toFieldValue),
+        rows: values.slice(1).map((row) => row.map(toFieldValue)),
+    };
+}
 
-    return values
-        .slice(1)
+// Positions in `rows` of every entry with the given name and prefecture, both
+// matched exactly.
+function findRows(fields, rows, name, pref) {
+    const nameIndex = fields.indexOf(NAME_FIELD);
+    const prefIndex = fields.indexOf(PREF_FIELD);
+    const found = [];
+    rows.forEach((row, index) => {
+        if (row[nameIndex] === name && row[prefIndex] === pref) {
+            found.push(index);
+        }
+    });
+    return found;
+}
+
+// Every entry in the sheet, as objects keyed by the header labels.
+function listEntries() {
+    const { fields, rows } = readPlanSheet();
+
+    return rows
         .map((row) => {
             const entry = {};
             fields.forEach((field, index) => {
-                entry[field] = toFieldValue(row[index]);
+                entry[field] = row[index];
             });
             return entry;
         })
-        .filter((entry) => String(entry[NAME_FIELD]).trim() !== '');
+        .filter((entry) => entry[NAME_FIELD] !== '');
 }
 
-// Overwrite the fields given in `values` on the entry identified by `name`.
-// Fields left out of `values` keep their current content.
-function updateEntry(name, values) {
-    const sheet = getPlanSheet();
-    const columns = getColumnIndexes(sheet);
-    const row = findRowByName(sheet, columns[NAME_FIELD], name);
-    if (row === -1) {
-        return { updated: false, row: null };
+// Overwrite the fields given in `values` on the entry identified by `name` and
+// `pref`. Fields left out of `values` keep their current content.
+//
+// Nothing is written unless exactly one entry matches: writing to the first of
+// several rows would update the wrong one unnoticed. `matched` tells the two
+// failures apart -- 0 is a miss, more than 1 means the sheet holds duplicate
+// rows, which the key cannot split.
+function updateEntry(name, pref, values) {
+    const { sheet, fields, rows } = readPlanSheet();
+    const found = findRows(fields, rows, toKeyValue(name), toKeyValue(pref));
+    if (found.length !== 1) {
+        return { updated: false, row: null, matched: found.length };
     }
 
+    const row = found[0] + 2;
     Object.keys(values).forEach((field) => {
-        sheet.getRange(row, columns[field]).setValue(values[field]);
+        sheet.getRange(row, fields.indexOf(field) + 1).setValue(values[field]);
     });
 
-    return { updated: true, row };
+    return { updated: true, row, matched: 1 };
 }

--- a/src/lib/plan-api.test.ts
+++ b/src/lib/plan-api.test.ts
@@ -62,19 +62,20 @@ describe('plan-api', () => {
     });
 
     describe('update', () => {
-        it('POSTs the name and values as text/plain', async () => {
-            fetchMock.mockResolvedValueOnce(jsonResponse({ updated: true, row: 12 }));
+        it('POSTs the key and values as text/plain', async () => {
+            fetchMock.mockResolvedValueOnce(jsonResponse({ updated: true, row: 12, matched: 1 }));
 
-            const result = await update('道の駅あ', { status: '開業', date: '2026-04-01' });
+            const result = await update('道の駅 川崎町', '福岡県', { status: '開業', date: '2026-04-01' });
 
-            expect(result).toEqual({ updated: true, row: 12 });
+            expect(result).toEqual({ updated: true, row: 12, matched: 1 });
             expect(fetchMock).toHaveBeenCalledWith(
                 API_URL,
                 expect.objectContaining({
                     method: 'POST',
                     headers: { 'Content-Type': 'text/plain' },
                     body: JSON.stringify({
-                        name: '道の駅あ',
+                        name: '道の駅 川崎町',
+                        pref: '福岡県',
                         values: { status: '開業', date: '2026-04-01' },
                     }),
                 })
@@ -82,27 +83,31 @@ describe('plan-api', () => {
         });
 
         it('passes through a miss so the caller can report it', async () => {
-            fetchMock.mockResolvedValueOnce(jsonResponse({ updated: false, row: null }));
+            fetchMock.mockResolvedValueOnce(jsonResponse({ updated: false, row: null, matched: 0 }));
 
-            expect(await update('道の駅ない', { status: '開業' })).toEqual({ updated: false, row: null });
+            expect(await update('道の駅ない', '福井県', { status: '開業' })).toEqual({
+                updated: false,
+                row: null,
+                matched: 0,
+            });
         });
 
         it('reports a non-OK status', async () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({}, 403));
 
-            await expect(update('道の駅あ', { status: '開業' })).rejects.toThrow('Failed to update: 403');
+            await expect(update('道の駅あ', '福井県', { status: '開業' })).rejects.toThrow('Failed to update: 403');
         });
 
         it('reports a non-JSON response body', async () => {
             fetchMock.mockResolvedValueOnce(new Response(HTML_ERROR_PAGE));
 
-            await expect(update('道の駅あ', { status: '開業' })).rejects.toThrow('non-JSON response');
+            await expect(update('道の駅あ', '福井県', { status: '開業' })).rejects.toThrow('non-JSON response');
         });
 
         it('reports an unset PLAN_API_URL instead of fetching', async () => {
             delete process.env.PLAN_API_URL;
 
-            await expect(update('道の駅あ', { status: '開業' })).rejects.toThrow('PLAN_API_URL is not set');
+            await expect(update('道の駅あ', '福井県', { status: '開業' })).rejects.toThrow('PLAN_API_URL is not set');
             expect(fetchMock).not.toHaveBeenCalled();
         });
     });

--- a/src/lib/plan-api.ts
+++ b/src/lib/plan-api.ts
@@ -16,6 +16,9 @@ export type PlanEntry = Record<string, string | number | boolean>;
 export interface UpdateResult {
     updated: boolean;
     row: number | null;
+    // How many entries the key selected. Nothing is written unless this is 1;
+    // see gas/plan.js.
+    matched: number;
 }
 
 // How much of an unexpected (HTML) response body to quote back.
@@ -52,14 +55,15 @@ export async function list(): Promise<PlanEntry[]> {
     return (await readJson(response, 'list')) as PlanEntry[];
 }
 
-// Overwrite the given fields on the entry named `name`. Fields left out keep
-// their current content.
-export async function update(name: string, values: Record<string, string>): Promise<UpdateResult> {
+// Overwrite the given fields on the entry keyed by `name` and `pref`, both of
+// which are required (see gas/plan.js). Fields left out keep their current
+// content.
+export async function update(name: string, pref: string, values: Record<string, string>): Promise<UpdateResult> {
     const response = await fetch(getApiUrl(), {
         method: 'POST',
         // text/plain keeps this a CORS simple request; see gas/Code.js.
         headers: { 'Content-Type': 'text/plain' },
-        body: JSON.stringify({ name, values }),
+        body: JSON.stringify({ name, pref, values }),
     });
     return (await readJson(response, 'update')) as UpdateResult;
 }

--- a/src/scripts/plan.test.ts
+++ b/src/scripts/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildValues, parseArgs } from './plan';
+import { buildKey, buildValues, parseArgs } from './plan';
 
 describe('parseArgs', () => {
     it('takes the command from the first positional', () => {
@@ -33,6 +33,45 @@ describe('parseArgs', () => {
     });
 });
 
+describe('buildKey', () => {
+    it('takes the name and the prefecture from the two positionals', () => {
+        expect(buildKey(['道の駅 川崎町', '福岡県'])).toEqual({ name: '道の駅 川崎町', pref: '福岡県' });
+    });
+
+    it('trims both halves, keeping stray spaces out of the messages built from them', () => {
+        expect(buildKey([' 道の駅あ ', ' 福井県 '])).toEqual({ name: '道の駅あ', pref: '福井県' });
+    });
+
+    it.each([[[]], [['']], [['  ', '福井県']]])('rejects the positionals %j as a missing name', (positionals) => {
+        expect(() => buildKey(positionals)).toThrow('Missing entry name');
+    });
+
+    it.each([[['道の駅あ']], [['道の駅あ', '']], [['道の駅あ', '  ']]])(
+        'rejects the positionals %j as a missing prefecture',
+        (positionals) => {
+            expect(() => buildKey(positionals)).toThrow('Missing prefecture for 道の駅あ');
+        }
+    );
+
+    it.each([
+        [['道の駅', '川崎町', '福岡県'], '"道の駅 川崎町" 福岡県'],
+        [['道の駅', 'スタープラザ', '芦別', '北海道'], '"道の駅 スタープラザ 芦別" 北海道'],
+    ])('quotes %j back as %s, the name an unquoted argument list split apart', (positionals, quoted) => {
+        expect(() => buildKey(positionals)).toThrow(`Unexpected extra arguments. Quote the name: ${quoted}`);
+    });
+
+    it.each([
+        [['道の駅', '川崎町'], '川崎町'],
+        [['道の駅', 'スタープラザ', '芦別'], '芦別'],
+    ])('reports %j as the invalid prefecture %s, an unquoted name given no prefecture at all', (positionals, pref) => {
+        expect(() => buildKey(positionals)).toThrow(`Invalid prefecture: ${pref}`);
+    });
+
+    it.each(['東京都', '北海道', '京都府'])('accepts the %s suffix as well as 県', (pref) => {
+        expect(buildKey(['道の駅あ', pref]).pref).toBe(pref);
+    });
+});
+
 describe('buildValues', () => {
     it('passes through the updatable fields', () => {
         expect(buildValues({ status: '開業', date: '2026-04-01', memo: 'https://example.com' })).toEqual({
@@ -63,8 +102,11 @@ describe('buildValues', () => {
         expect(() => buildValues({ name: '  ' })).toThrow('Invalid --name');
     });
 
-    it.each(['pref', 'city'])('rejects %s, which places an entry rather than describing it', (field) => {
-        expect(() => buildValues({ [field]: '福井県' })).toThrow(`Unknown field: --${field}`);
+    it.each([
+        ['pref', '福井県'],
+        ['city', '福井市'],
+    ])('rejects %s, which is not a column describing progress', (field, value) => {
+        expect(() => buildValues({ [field]: value })).toThrow(`Unknown field: --${field}`);
     });
 
     it("rejects a status outside the sheet's four values", () => {

--- a/src/scripts/plan.ts
+++ b/src/scripts/plan.ts
@@ -1,7 +1,7 @@
 // Command-line client for the development-plan spreadsheet API.
 //
 //   npm run --silent plan:list
-//   npm run plan:update -- "道の駅◯◯" --status=開業 --date=2026-04-01
+//   npm run plan:update -- "道の駅◯◯" 福井県 --status=開業 --date=2026-04-01
 //
 // `list` prints the sheet as JSON and does no filtering or formatting of its
 // own; jq does that far better than any set of flags would. Because of that its
@@ -19,26 +19,32 @@ import { list, update } from '../lib/plan-api.js';
 const STATUSES = ['開業', '登録済み', '計画中', '中止'];
 
 // Columns update accepts, matching the sheet's header labels. `pref` and `city`
-// are left out: they place an entry rather than describe its progress, and
-// `city` also drives the map's fallback to the municipality's representative
-// point. Correcting them is done in the spreadsheet, where the change is
-// visible in context.
+// are left out: `pref` is half of the key, and `city` places an entry rather
+// than describing its progress, driving the map's fallback to the
+// municipality's representative point. Correcting them is done in the
+// spreadsheet, where the change is visible in context.
 const UPDATABLE_FIELDS = ['name', 'status', 'date', 'lat', 'lng', 'memo'];
+
+// The usage line buildKey's errors point at.
+const KEY_USAGE = 'npm run plan:update -- "<name>" <prefecture> --status=開業';
 
 const USAGE = `Read and update the roadside-station development-plan spreadsheet.
 
 Usage:
   npm run --silent plan:list
-  npm run plan:update -- "<name>" [--name=<new name>] [--status=<status>]
-                                  [--date=<text>] [--lat=<number>]
-                                  [--lng=<number>] [--memo=<text>]
+  npm run plan:update -- "<name>" <prefecture> [--name=<new name>]
+                                               [--status=<status>] [--date=<text>]
+                                               [--lat=<number>] [--lng=<number>]
+                                               [--memo=<text>]
 
 Commands:
   list     Print every entry as JSON. Filter it with jq:
              npm run --silent plan:list | jq -r '.[] | select(.status == "計画中") | .name'
            Note the --silent: without it npm prints its banner to stdout and jq
            fails to parse the output.
-  update   Overwrite the given fields on the entry whose name matches exactly.
+  update   Overwrite the given fields on the entry matched exactly by the name
+           and prefecture given as positional arguments. Both are required:
+           names are not unique across prefectures.
            Fields left out keep their current content; pass an empty value
            (e.g. --date=) to clear a field -- except --name, which every entry
            is identified by. pref and city are not writable here -- correct
@@ -114,6 +120,38 @@ function validateField(field: string, value: string): void {
     }
 }
 
+// The key of the entry to update, taken from the two positional arguments: its
+// name and its prefecture. Both are trimmed, so what is sent and what is printed
+// carry no stray spaces.
+export function buildKey(positionals: string[]): { name: string; pref: string } {
+    // Station names hold spaces (道の駅 川崎町), so an unquoted one arrives split
+    // across several arguments. The prefecture is the last of them either way.
+    const args = positionals.map((positional) => positional.trim());
+    const name = args[0];
+    const pref = args.length > 1 ? args[args.length - 1] : '';
+
+    if (!name) {
+        throw new Error(`Missing entry name. Usage: ${KEY_USAGE}`);
+    }
+    if (!pref) {
+        throw new Error(`Missing prefecture for ${name}. Names are not unique across prefectures. Usage: ${KEY_USAGE}`);
+    }
+    // Checked before the argument count, so an unquoted name that also lacks a
+    // prefecture is reported as a problem with the prefecture rather than as a
+    // quoting slip whose suggested fix fails in turn.
+    if (!/[都道府県]$/.test(pref)) {
+        throw new Error(
+            `Invalid prefecture: ${pref}. Expected a name ending in 都/道/府/県 -- quote a station name ` +
+                `that holds spaces. Usage: ${KEY_USAGE}`
+        );
+    }
+    if (args.length > 2) {
+        throw new Error(`Unexpected extra arguments. Quote the name: "${args.slice(0, -1).join(' ')}" ${pref}`);
+    }
+
+    return { name, pref };
+}
+
 export function buildValues(flags: Record<string, string>): Record<string, string> {
     const values: Record<string, string> = {};
 
@@ -145,18 +183,15 @@ async function runList(): Promise<void> {
 }
 
 async function runUpdate(parsed: ParsedArgs): Promise<void> {
-    const name = parsed.positionals[0];
-    if (name === undefined || name === '') {
-        throw new Error('Missing entry name. Usage: npm run plan:update -- "<name>" --status=開業');
-    }
-
+    const { name, pref } = buildKey(parsed.positionals);
     const values = buildValues(parsed.flags);
-    const result = await update(name, values);
+
+    const result = await update(name, pref, values);
     if (!result.updated) {
-        throw new Error(`Entry not found: ${name}`);
+        throw new Error(`Update error: ${name} (${pref}) (matched: ${result.matched})`);
     }
 
-    console.error(`Updated ${name} (row ${result.row}).`);
+    console.error(`Updated ${name} (${pref}) (row ${result.row}).`);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

A station name is not unique across prefectures — 道の駅 川崎町 exists in both 福岡県 (計画中, 2027) and 宮城県 (中止) — so `plan:update` wrote to whichever row came first, with no sign that the other one existed. An entry is now keyed on its name **and** prefecture, and a write happens only when exactly one entry matches.

## Key Changes

- **GAS backend** (`gas/plan.js`)
  - `findRowByName()` → `findRows()`: matches the `name` and `pref` columns together and returns every match
  - `updateEntry()` writes only when exactly one entry matches, and returns that count as `matched` so a miss (0) and duplicate rows (2 or more) stay distinguishable
  - The sheet is read in one place, `readPlanSheet()`, which normalizes every value it hands out (Date → `yyyy-MM-dd`, text trimmed). Nothing downstream normalizes again, so a value listed by `doGet` is the value a lookup matches on. `getColumnIndexes()` is gone with it
- **API client** (`src/lib/plan-api.ts`): `update(name, pref, values)` — the key mirrors the request body and the Apps Script signature; `UpdateResult` carries `matched`
- **CLI** (`src/scripts/plan.ts`)
  - The prefecture is the **second positional argument**, not a flag: `npm run plan:update -- "道の駅 川崎町" 福岡県 --status=開業`
  - New `buildKey()` builds and validates the key: it rejects a missing name or prefecture, a last argument that is not a prefecture (does not end in 都/道/府/県), and arguments left over in front of it — the last two are both an unquoted name split on its spaces, and the error quotes the name back
  - `buildValues()` rejects `--pref` as an unknown field, like the other non-progress columns
  - A refused write is reported as `Update error: 道の駅 川崎町 (福岡県) (matched: 2)`
- **CLAUDE.md**: the identification rule, the request/response shape and the CLI notes follow the above

## Why the key is positional and required

The only caller is Claude Code, right after reading `plan:list`, so the prefecture is always at hand. Required keys as long options would look like the optional update fields; as positionals the two roles are told apart by shape. Requiring it also removes the "no pref means no narrowing" branch from the Apps Script, the CLI and the client, and separates the failures: no match means the pair is absent, several means the sheet holds duplicate rows that no argument can split.

## Tests

`src/scripts/plan.test.ts` — `describe('buildKey')` is new:

| Example | What it covers |
|---|---|
| `takes the name and the prefecture from the two positionals` | the key is built from the positionals |
| `trims both halves, keeping stray spaces out of the messages built from them` | both halves are trimmed |
| `rejects the positionals %j as a missing name` | missing, empty and blank names |
| `rejects the positionals %j as a missing prefecture` | a single positional, and an empty or blank second one |
| `quotes %j back as %s, the name an unquoted argument list split apart` | leftover arguments are quoted back as `"道の駅 スタープラザ 芦別" 北海道`, for 3 and 4 arguments |
| `reports %j as the invalid prefecture %s, an unquoted name given no prefecture at all` | the prefecture is checked before the argument count, so this case is not reported as a quoting slip whose fix would fail in turn |
| `accepts the %s suffix as well as 県` | 東京都 / 北海道 / 京都府 |

`buildValues` — `rejects %s, which is not a column describing progress` now covers `pref` alongside `city`.

`src/lib/plan-api.test.ts` — existing cases updated for the `update(name, pref, values)` signature and the `matched` field.

## Note

`gas/` is not deployed by merging this PR; it needs `npm run gas:push`. Until then the deployed Apps Script matches on the name alone and returns no `matched`.

https://claude.ai/code/session_01GNeWnXNKGriBBLHufrAzXa
