### PR TITLE
Add `plan:show` command to look up single development plan entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@
 - **フロントエンド**: `npm start`（ウォッチビルド） / `npm run serve`（開発サーバー、ポート 8081） / `npm run build`
 - **バックエンド**: `npm run dev:backend`（wrangler dev） / `npm run deploy:backend` / `npm run db:migrate:local` / `npm run db:migrate`
 - **データ生成**: `npm run generate:all`（`generate:stations` → `generate:geojson`）
-- **開発計画データ**: `npm run --silent plan:list` / `npm run plan:update`（`.env` の `PLAN_API_URL` が必要）
+- **開発計画データ**: `npm run --silent plan:list` / `npm run --silent plan:show` / `npm run plan:update`（`.env` の `PLAN_API_URL` が必要）
 - **品質**: `npm test` / `npm run lint` / `npm run format` / `npm run typecheck` / `npm run lint:fix`
 
 ### generate:stations のデバッグモード
@@ -154,17 +154,18 @@ POST https://script.google.com/macros/s/xxx/exec   (Content-Type: text/plain)
 
 ### 開発計画データ CLI（`npm run plan:*`）
 
-上記 API の唯一のクライアント。`src/scripts/plan.ts`（エントリーポイント、引数解析・検証）と `src/lib/plan-api.ts`（通信）。
+上記 API の唯一のクライアント。`src/scripts/plan.ts`（エントリーポイント、引数解析・検証）と `src/lib/plan-api.ts`（通信）。コマンドは `list`（全件）/ `show`（1 件）/ `update`（更新）の 3 つ。
 
 ```
 npm run --silent plan:list | jq -r '.[] | select(.status == "計画中") | .name'
+npm run --silent plan:show -- "道の駅◯◯" 福井県
 npm run plan:update -- "道の駅◯◯" 福井県 --status=開業 --date=2026-04-01
 npm run plan:update -- "道の駅◯◯（仮称）" 福井県 --name=道の駅◯◯
 ```
 
-- **`list` は JSON を出すだけ**で絞り込み・整形のオプションを持たない。`jq` のほうが上手くやれるため
+- **`list` / `show` は JSON を出すだけ**で絞り込み・整形のオプションを持たない。`jq` のほうが上手くやれるため
 - **`npm run` のバナーは stdout に出る**ので、`jq` に流すときは `--silent` が要る
-- **script 名は `plan:list` / `plan:update`**: `db:migrate` / `gas:push` と同じ `<名前空間>:<動詞>` 形式に揃える。サブコマンドを script 側に埋めてあるので、`list` は `--` なしで `jq` に流せる
+- **script 名は `plan:list` / `plan:show` / `plan:update`**: `db:migrate` / `gas:push` と同じ `<名前空間>:<動詞>` 形式に揃える。サブコマンドを script 側に埋めてあるので、`list` は `--` なしで `jq` に流せる
 - **`update` は送信前に検証する**: 更新可能フィールド（`name` / `status` / `date` / `lat` / `lng` / `memo`）以外のフラグ、範囲外の `status`、非数値の座標、空の `name`、フィールド無指定、キー（名前・都道府県）の欠落や不正を弾く。GAS 側にエラー処理がなく、不正入力は HTML のエラーページとして返るため
 - **`date` は検証しない**: シートは判明している粒度をそのまま記録するため、`2026-04-01` / `2026-04` / `2026` / `2026夏` のいずれもありうる。単一のパターンに押し込められない
 - **`pref` / `city` は更新対象外**: エントリーを同定・配置する列で、進捗を表す列ではない（`city` は地図の市区町村代表点フォールバックの引き当てに使う）。修正は文脈の見えるスプレッドシート上で行う

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "db:migrate": "wrangler d1 migrations apply DB --remote --env production",
         "gas:push": "clasp push -f && clasp deploy -i $CLASP_DEPLOY_ID",
         "plan:list": "NODE_USE_ENV_PROXY=1 node --import tsx src/scripts/plan.ts list",
+        "plan:show": "NODE_USE_ENV_PROXY=1 node --import tsx src/scripts/plan.ts show",
         "plan:update": "NODE_USE_ENV_PROXY=1 node --import tsx src/scripts/plan.ts update",
         "generate:geojson": "node --import tsx src/scripts/generate-geojson.ts",
         "generate:stations": "NODE_USE_ENV_PROXY=1 node --import tsx src/scripts/generate-stationlist.ts",

--- a/src/scripts/plan.test.ts
+++ b/src/scripts/plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildKey, buildValues, parseArgs } from './plan';
+import type { PlanEntry } from '../lib/plan-api';
+import { buildKey, buildValues, parseArgs, rejectFlags, selectEntry } from './plan';
 
 describe('parseArgs', () => {
     it('takes the command from the first positional', () => {
@@ -35,21 +36,21 @@ describe('parseArgs', () => {
 
 describe('buildKey', () => {
     it('takes the name and the prefecture from the two positionals', () => {
-        expect(buildKey(['道の駅 川崎町', '福岡県'])).toEqual({ name: '道の駅 川崎町', pref: '福岡県' });
+        expect(buildKey(['道の駅 川崎町', '福岡県'], 'update')).toEqual({ name: '道の駅 川崎町', pref: '福岡県' });
     });
 
     it('trims both halves, keeping stray spaces out of the messages built from them', () => {
-        expect(buildKey([' 道の駅あ ', ' 福井県 '])).toEqual({ name: '道の駅あ', pref: '福井県' });
+        expect(buildKey([' 道の駅あ ', ' 福井県 '], 'update')).toEqual({ name: '道の駅あ', pref: '福井県' });
     });
 
     it.each([[[]], [['']], [['  ', '福井県']]])('rejects the positionals %j as a missing name', (positionals) => {
-        expect(() => buildKey(positionals)).toThrow('Missing entry name');
+        expect(() => buildKey(positionals, 'update')).toThrow('Missing entry name');
     });
 
     it.each([[['道の駅あ']], [['道の駅あ', '']], [['道の駅あ', '  ']]])(
         'rejects the positionals %j as a missing prefecture',
         (positionals) => {
-            expect(() => buildKey(positionals)).toThrow('Missing prefecture for 道の駅あ');
+            expect(() => buildKey(positionals, 'update')).toThrow('Missing prefecture for 道の駅あ');
         }
     );
 
@@ -57,18 +58,63 @@ describe('buildKey', () => {
         [['道の駅', '川崎町', '福岡県'], '"道の駅 川崎町" 福岡県'],
         [['道の駅', 'スタープラザ', '芦別', '北海道'], '"道の駅 スタープラザ 芦別" 北海道'],
     ])('quotes %j back as %s, the name an unquoted argument list split apart', (positionals, quoted) => {
-        expect(() => buildKey(positionals)).toThrow(`Unexpected extra arguments. Quote the name: ${quoted}`);
+        expect(() => buildKey(positionals, 'update')).toThrow(`Unexpected extra arguments. Quote the name: ${quoted}`);
     });
 
     it.each([
         [['道の駅', '川崎町'], '川崎町'],
         [['道の駅', 'スタープラザ', '芦別'], '芦別'],
     ])('reports %j as the invalid prefecture %s, an unquoted name given no prefecture at all', (positionals, pref) => {
-        expect(() => buildKey(positionals)).toThrow(`Invalid prefecture: ${pref}`);
+        expect(() => buildKey(positionals, 'update')).toThrow(`Invalid prefecture: ${pref}`);
     });
 
     it.each(['東京都', '北海道', '京都府'])('accepts the %s suffix as well as 県', (pref) => {
-        expect(buildKey(['道の駅あ', pref]).pref).toBe(pref);
+        expect(buildKey(['道の駅あ', pref], 'update').pref).toBe(pref);
+    });
+
+    it.each([
+        ['show', 'npm run --silent plan:show'],
+        ['update', 'npm run plan:update'],
+    ] as const)('points %s at its own usage line', (command, usage) => {
+        expect(() => buildKey([], command)).toThrow(usage);
+    });
+});
+
+describe('rejectFlags', () => {
+    it('accepts a command given no options', () => {
+        expect(() => rejectFlags('list', {})).not.toThrow();
+    });
+
+    it('names the offending option and points at both jq and update, the two things it could have meant', () => {
+        expect(() => rejectFlags('show', { status: '開業' })).toThrow(
+            /Unknown option: --status\. show only reads .*jq.*plan:update/
+        );
+    });
+});
+
+describe('selectEntry', () => {
+    const entries: PlanEntry[] = [
+        { name: '道の駅 川崎町', pref: '福岡県', status: '計画中' },
+        { name: '道の駅 川崎町', pref: '宮城県', status: '開業' },
+        { name: '道の駅あ', pref: '福井県', status: '計画中' },
+    ];
+
+    it('matches on the name and the prefecture together', () => {
+        expect(selectEntry(entries, '道の駅 川崎町', '宮城県')).toEqual({
+            name: '道の駅 川崎町',
+            pref: '宮城県',
+            status: '開業',
+        });
+    });
+
+    it('rejects a name held by no entry of that prefecture', () => {
+        expect(() => selectEntry(entries, '道の駅あ', '宮城県')).toThrow('No entry named 道の駅あ in 宮城県');
+    });
+
+    it('reports a duplicate with its count instead of picking one of the rows', () => {
+        const duplicated = [...entries, { name: '道の駅あ', pref: '福井県', status: '中止' }];
+
+        expect(() => selectEntry(duplicated, '道の駅あ', '福井県')).toThrow('2 entries named 道の駅あ in 福井県');
     });
 });
 

--- a/src/scripts/plan.ts
+++ b/src/scripts/plan.ts
@@ -1,16 +1,16 @@
 // Command-line client for the development-plan spreadsheet API.
 //
 //   npm run --silent plan:list
+//   npm run --silent plan:show -- "道の駅◯◯" 福井県
 //   npm run plan:update -- "道の駅◯◯" 福井県 --status=開業 --date=2026-04-01
 //
-// `list` prints the sheet as JSON and does no filtering or formatting of its
-// own; jq does that far better than any set of flags would. Because of that its
-// stdout is kept to JSON alone, and everything else (progress, success
-// messages, errors) goes to stderr.
+// `list` and `show` take no filtering or formatting options; jq does that far
+// better than any set of flags would. Their stdout is kept to JSON alone, and
+// everything else (progress, success messages, errors) goes to stderr.
 
 import { fileURLToPath } from 'node:url';
 import { config } from 'dotenv';
-import { list, update } from '../lib/plan-api.js';
+import { list, type PlanEntry, update } from '../lib/plan-api.js';
 
 // The sheet's four status values. Out-of-range values are silently rendered as
 // 計画中 by the map, so they are rejected here rather than written. Kept as a
@@ -25,13 +25,22 @@ const STATUSES = ['開業', '登録済み', '計画中', '中止'];
 // spreadsheet, where the change is visible in context.
 const UPDATABLE_FIELDS = ['name', 'status', 'date', 'lat', 'lng', 'memo'];
 
-// The usage line buildKey's errors point at.
-const KEY_USAGE = 'npm run plan:update -- "<name>" <prefecture> --status=開業';
+// The commands that take an entry key -- a name and a prefecture -- rather than
+// operating on the sheet as a whole.
+type KeyedCommand = 'show' | 'update';
+
+// The usage line per keyed command. An error points at whichever command should
+// have been used, which is not always the one that raised it.
+const KEY_USAGE: Record<KeyedCommand, string> = {
+    show: 'npm run --silent plan:show -- "<name>" <prefecture>',
+    update: 'npm run plan:update -- "<name>" <prefecture> --status=開業',
+};
 
 const USAGE = `Read and update the roadside-station development-plan spreadsheet.
 
 Usage:
   npm run --silent plan:list
+  npm run --silent plan:show -- "<name>" <prefecture>
   npm run plan:update -- "<name>" <prefecture> [--name=<new name>]
                                                [--status=<status>] [--date=<text>]
                                                [--lat=<number>] [--lng=<number>]
@@ -42,6 +51,9 @@ Commands:
              npm run --silent plan:list | jq -r '.[] | select(.status == "計画中") | .name'
            Note the --silent: without it npm prints its banner to stdout and jq
            fails to parse the output.
+  show     Print the single entry matched exactly by the name and prefecture
+           given as positional arguments -- the same key update writes by -- as
+           JSON. Takes no options; pipe it through jq to pick fields out.
   update   Overwrite the given fields on the entry matched exactly by the name
            and prefecture given as positional arguments. Both are required:
            names are not unique across prefectures.
@@ -120,10 +132,12 @@ function validateField(field: string, value: string): void {
     }
 }
 
-// The key of the entry to update, taken from the two positional arguments: its
-// name and its prefecture. Both are trimmed, so what is sent and what is printed
-// carry no stray spaces.
-export function buildKey(positionals: string[]): { name: string; pref: string } {
+// The key of the entry to show or update, taken from the two positional
+// arguments: its name and its prefecture. Both are trimmed, so what is sent and
+// what is printed carry no stray spaces. `command` only picks the usage line the
+// errors point at.
+export function buildKey(positionals: string[], command: KeyedCommand): { name: string; pref: string } {
+    const usage = KEY_USAGE[command];
     // Station names hold spaces (道の駅 川崎町), so an unquoted one arrives split
     // across several arguments. The prefecture is the last of them either way.
     const args = positionals.map((positional) => positional.trim());
@@ -131,10 +145,10 @@ export function buildKey(positionals: string[]): { name: string; pref: string } 
     const pref = args.length > 1 ? args[args.length - 1] : '';
 
     if (!name) {
-        throw new Error(`Missing entry name. Usage: ${KEY_USAGE}`);
+        throw new Error(`Missing entry name. Usage: ${usage}`);
     }
     if (!pref) {
-        throw new Error(`Missing prefecture for ${name}. Names are not unique across prefectures. Usage: ${KEY_USAGE}`);
+        throw new Error(`Missing prefecture for ${name}. Names are not unique across prefectures. Usage: ${usage}`);
     }
     // Checked before the argument count, so an unquoted name that also lacks a
     // prefecture is reported as a problem with the prefecture rather than as a
@@ -142,7 +156,7 @@ export function buildKey(positionals: string[]): { name: string; pref: string } 
     if (!/[都道府県]$/.test(pref)) {
         throw new Error(
             `Invalid prefecture: ${pref}. Expected a name ending in 都/道/府/県 -- quote a station name ` +
-                `that holds spaces. Usage: ${KEY_USAGE}`
+                `that holds spaces. Usage: ${usage}`
         );
     }
     if (args.length > 2) {
@@ -177,13 +191,55 @@ export function buildValues(flags: Record<string, string>): Record<string, strin
     return values;
 }
 
-async function runList(): Promise<void> {
+// Neither read command takes options. An option here is either a filter, which
+// jq does, or one of update's fields, so the error points at both.
+export function rejectFlags(command: 'list' | 'show', flags: Record<string, string>): void {
+    const [flag] = Object.keys(flags);
+    if (flag) {
+        throw new Error(
+            `Unknown option: --${flag}. ${command} only reads -- pipe its JSON through jq, ` +
+                `or write with: ${KEY_USAGE.update}`
+        );
+    }
+}
+
+// The one entry a key selects. doGet has no per-entry read and returns the whole
+// sheet, so the key is matched here, by the same exact equality on both columns
+// that gas/plan.js uses for update -- which also refuses to write when the key
+// matches more than one row.
+export function selectEntry(entries: PlanEntry[], name: string, pref: string): PlanEntry {
+    const matched = entries.filter((entry) => entry.name === name && entry.pref === pref);
+
+    if (matched.length === 0) {
+        throw new Error(`No entry named ${name} in ${pref}.`);
+    }
+    if (matched.length > 1) {
+        throw new Error(`${matched.length} entries named ${name} in ${pref}. Remove the duplicate in the sheet.`);
+    }
+
+    return matched[0];
+}
+
+async function runList(parsed: ParsedArgs): Promise<void> {
+    rejectFlags('list', parsed.flags);
+    if (parsed.positionals.length > 0) {
+        throw new Error(`list takes no arguments. To look one entry up: ${KEY_USAGE.show}`);
+    }
+
     const entries = await list();
     process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
 }
 
+async function runShow(parsed: ParsedArgs): Promise<void> {
+    rejectFlags('show', parsed.flags);
+    const { name, pref } = buildKey(parsed.positionals, 'show');
+
+    const entry = selectEntry(await list(), name, pref);
+    process.stdout.write(`${JSON.stringify(entry, null, 2)}\n`);
+}
+
 async function runUpdate(parsed: ParsedArgs): Promise<void> {
-    const { name, pref } = buildKey(parsed.positionals);
+    const { name, pref } = buildKey(parsed.positionals, 'update');
     const values = buildValues(parsed.flags);
 
     const result = await update(name, pref, values);
@@ -206,7 +262,10 @@ async function main(): Promise<void> {
 
     switch (parsed.command) {
         case 'list':
-            await runList();
+            await runList(parsed);
+            break;
+        case 'show':
+            await runShow(parsed);
             break;
         case 'update':
             await runUpdate(parsed);


### PR DESCRIPTION
Add a new `plan:show` subcommand to the development plan CLI that retrieves and displays a single entry by name and prefecture, complementing the existing `plan:list` (all entries) and `plan:update` (modify entry) commands.

## Summary

The `plan:show` command addresses a common workflow: checking the current values of an entry before updating it. Previously, users had to pipe `plan:list` output through `jq` to filter by name and prefecture, which is verbose. The new command provides a dedicated, concise way to look up a single entry using the same key format as `plan:update`.

## Key Changes

- **New `plan:show` command**: Takes name and prefecture as positional arguments (same format as `update`), returns the matched entry as JSON
  - Performs client-side filtering since the API returns the full sheet
  - Validates that exactly one entry matches; errors on 0 or multiple matches
  - Rejects any options (flags) to prevent confusion with `update` field flags

- **Refactored key handling**: 
  - `buildKey()` now takes a `command` parameter to point error messages at the correct usage line
  - New `KeyedCommand` type (`'show' | 'update'`) to track which commands take entry keys
  - `KEY_USAGE` changed from a string to a `Record<KeyedCommand, string>` for command-specific help text

- **New validation functions**:
  - `rejectFlags()`: Validates that read-only commands (`list`, `show`) receive no options; errors point at both `jq` (for filtering) and `plan:update` (for writing)
  - `selectEntry()`: Filters entries by name and prefecture; reports exact match count to catch duplicates in the sheet

- **Updated `runList()`**: Now validates that no positional arguments are passed; suggests `plan:show` if user tries to filter by name/prefecture

- **Updated documentation**: 
  - Added `plan:show` to usage text and examples
  - Updated CLAUDE.md with command descriptions and design rationale
  - Updated package.json scripts

## Implementation Details

- **No server-side filtering**: The API (`doGet`) returns the entire sheet, so matching is done client-side using the same exact-match logic as the GAS `update` function
- **Duplicate detection**: If multiple entries match the key, the error reports the count and directs the user to fix the spreadsheet rather than silently picking one
- **Consistent error handling**: Both `list` and `show` reject unexpected arguments/options with helpful error messages that point at the correct alternative command
- **Trimmed values**: Input and output are trimmed consistently with the API's behavior, ensuring the key used in `show` matches what `update` writes

https://claude.ai/code/session_018EmzLfCBTVAdw7oz7ACF9N