### PR TITLE
Add collapse/expand toggle to plan sidebar

### DIFF
--- a/html/css/plan.css
+++ b/html/css/plan.css
@@ -38,11 +38,54 @@ body,
     border-right: 1px solid #e0e0e0;
 }
 
+/* Sticks to the top so the collapse button stays reachable while the station
+   list below it scrolls. */
 .plan-sidebar-title {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 14px 16px;
+    background: #ffffff;
     font-size: 16px;
     font-weight: bold;
     border-bottom: 1px solid #eeeeee;
+}
+
+.plan-sidebar-collapse,
+.plan-sidebar-reopen {
+    flex: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #555;
+    font-size: 16px;
+    line-height: 1;
+}
+
+.plan-sidebar-collapse {
+    padding: 0 2px;
+}
+
+/* Collapsed sidebar: a narrow full-height strip holding the reopen arrow. */
+.plan-sidebar-reopen {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    width: 26px;
+    height: 100%;
+    /* Line the arrow up with the title bar it replaces. */
+    padding: 14px 0 0;
+    box-sizing: border-box;
+    background: #ffffff;
+    border-right: 1px solid #e0e0e0;
+}
+
+.plan-sidebar-collapse:hover,
+.plan-sidebar-reopen:hover {
+    color: #000000;
 }
 
 .plan-cat {

--- a/src/frontend/components/PlanSidebar.test.tsx
+++ b/src/frontend/components/PlanSidebar.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Category, PlannedStation } from '../types/plan';
+import { CATEGORIES } from '../types/plan';
+import { PlanSidebar } from './PlanSidebar';
+
+const stations: PlannedStation[] = [
+    {
+        name: '道の駅 X',
+        pref: '長野県',
+        city: '上伊那郡箕輪町',
+        status: '計画中',
+        date: '2026-04-01',
+        lat: 35.9,
+        lng: 137.9,
+        memo: '',
+        coordSource: 'exact',
+    },
+];
+
+const allVisible = Object.fromEntries(CATEGORIES.map((c) => [c, true])) as Record<Category, boolean>;
+
+const renderSidebar = () =>
+    render(
+        <PlanSidebar
+            stations={stations}
+            visibleCategories={allVisible}
+            selected={null}
+            onToggle={() => {}}
+            onSelect={() => {}}
+        />
+    );
+
+describe('PlanSidebar', () => {
+    // Vitest runs without globals, so React Testing Library's auto-cleanup is
+    // not registered; unmount explicitly to keep queries scoped to one render.
+    afterEach(cleanup);
+
+    it('renders the station list expanded by default', () => {
+        renderSidebar();
+
+        expect(screen.getByText('2026-04-01: 道の駅 X')).toBeTruthy();
+        expect(screen.getByLabelText('サイドバーを閉じる')).toBeTruthy();
+    });
+
+    it('collapses to the reopen strip and expands again', () => {
+        renderSidebar();
+
+        fireEvent.click(screen.getByLabelText('サイドバーを閉じる'));
+        expect(screen.queryByText('2026-04-01: 道の駅 X')).toBeNull();
+
+        fireEvent.click(screen.getByLabelText('サイドバーを開く'));
+        expect(screen.getByText('2026-04-01: 道の駅 X')).toBeTruthy();
+    });
+});

--- a/src/frontend/components/PlanSidebar.tsx
+++ b/src/frontend/components/PlanSidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { Category, PlannedStation } from '../types/plan';
 import { CATEGORIES, categoryOf } from '../types/plan';
 import { CATEGORY_ICON } from './PlanMarkers';
@@ -17,7 +18,27 @@ interface PlanSidebarProps {
 // Left panel listing stations grouped by category, mirroring the Google My Maps
 // sidebar: each category has a show/hide checkbox and, when visible, the list of
 // its stations. Clicking an item focuses it on the map.
+//
+// The panel collapses to a narrow strip to give the map the full width. The
+// collapsed/expanded state is component-local and not persisted: nothing else
+// depends on it, and reopening is a single click.
 export function PlanSidebar({ stations, visibleCategories, selected, onToggle, onSelect }: PlanSidebarProps) {
+    const [open, setOpen] = useState(true);
+
+    if (!open) {
+        return (
+            <button
+                type="button"
+                className="plan-sidebar-reopen"
+                title="サイドバーを開く"
+                aria-label="サイドバーを開く"
+                onClick={() => setOpen(true)}
+            >
+                »
+            </button>
+        );
+    }
+
     const byCategory = new Map<Category, PlannedStation[]>();
     for (const c of CATEGORIES) {
         byCategory.set(c, []);
@@ -32,6 +53,15 @@ export function PlanSidebar({ stations, visibleCategories, selected, onToggle, o
                 <a href={SHEET_EDIT_URL} target="_blank" rel="noopener noreferrer">
                     道の駅 整備計画
                 </a>
+                <button
+                    type="button"
+                    className="plan-sidebar-collapse"
+                    title="サイドバーを閉じる"
+                    aria-label="サイドバーを閉じる"
+                    onClick={() => setOpen(false)}
+                >
+                    «
+                </button>
             </div>
             {CATEGORIES.map((category) => {
                 const items = byCategory.get(category) ?? [];


### PR DESCRIPTION
## Summary
Added a collapsible sidebar feature to the development plan map. The sidebar can now collapse to a narrow strip showing only a reopen button, giving the map full width when the station list is not needed.

## Changes
- **PlanSidebar component**: Added local `open` state to toggle between expanded and collapsed views. When collapsed, renders a narrow button strip with a `»` reopen button. When expanded, displays the full station list with a `«` collapse button in the title bar.
- **Styling**: 
  - Made the sidebar title sticky so the collapse button remains accessible while scrolling the station list
  - Added button styles for collapse/reopen controls with hover effects
  - Styled the collapsed sidebar as a full-height 26px strip with centered reopen button
- **Tests**: Added comprehensive test suite for the collapse/expand functionality, verifying the sidebar renders expanded by default and toggles correctly between states.

## Implementation Details
- The collapsed/expanded state is component-local and not persisted, as nothing else depends on it and reopening is a single click
- Used semantic HTML buttons with proper `aria-label` attributes for accessibility
- The sticky title bar uses flexbox to align the title link and collapse button with proper spacing

https://claude.ai/code/session_011odqDT24PvZMB959879Cfe