### PR TITLE
Run npm run ci before committing

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Hook input is JSON from stdin
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name')
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Only run for git commit commands
+if [[ "$tool_name" != "Bash" ]] || [[ ! "$command" =~ git[[:space:]]+(commit|cherry-pick|merge|rebase) ]]; then
+    exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" || exit 1
+
+echo "Running pre-commit checks..." >&2
+
+if ! npm run ci >&2; then
+    echo "Error: npm run ci failed" >&2
+    exit 2
+fi
+
+echo "All checks passed!" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-check.sh",
+            "timeout": 300000
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/self-review.sh",
             "timeout": 10000
           }


### PR DESCRIPTION
Adds the TypeScript pre-commit hook introduced in [tk0miya/skills](https://github.com/tk0miya/skills) 119fd45, which `init-typescript-project` now installs for every TypeScript project.

`.claude/hooks/pre-commit-check.sh` runs `npm run ci` (lint / typecheck / test) before `git commit` and blocks the commit when it fails. Since `ci` is the same script `.github/workflows/ci.yml` runs, a commit that gets through also passes CI. The hook definition is merged into `.claude/settings.json` alongside the existing `self-review` hook.