### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.swp
 *.js.map
 


### PR DESCRIPTION
Syncs `.gitignore` with the `init-typescript-project` template in [tk0miya/skills](https://github.com/tk0miya/skills), which gained the entry in ebb69a6.

Finder drops `.DS_Store` into any directory it opens, so it can turn up anywhere in the tree. This file does not follow the template's ASCII ordering, so the entry goes next to the other editor/OS leftovers at the top.