### PR TITLE
Add coordinate copy feature to development plan map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ data/         生成データ（CSV / GeoJSON）と開発計画マスタ（plans
 - **並び替えるのは読み込み直後（`toPlannedStations()`）**: サイドバーはカテゴリごとに push するだけなので配列の順序がそのまま表示順になる。並び順をレンダリングなしでテストできる
 - **都道府県順は `data/cities.json` の並びから引く**: 全国地方公共団体コード順のテーブルそのもので、地図が既に読み込んでいる。47 件のリストをコード側に持つと二重管理になる
 
+開発計画マップは地図の右クリックでその地点の座標を `[lat, lng]` 形式でクリップボードにコピーする（`src/frontend/components/PlanCoordCopy.tsx`）。座標が未記入の駅を調査するとき、地図で位置を当てて `data/plans.json` の `lat` / `lng` に貼るための機能。丸め桁とブラウザの右クリックメニューを抑止する理由は同ファイルのコメントを参照。
+
 ### データパイプライン
 
 1. `generate-stationlist.ts` - michi-no-eki.jp を都道府県・駅の階層でたどり `data/stations.csv` を出力（`cheerio` で HTML 解析、`jaconv` でテキスト正規化）

--- a/html/css/plan.css
+++ b/html/css/plan.css
@@ -172,6 +172,23 @@ body,
     color: #1565c0;
 }
 
+/* Transient confirmation (coordinate copy). Sits at the top center, where the
+   default map controls leave room. */
+.plan-toast {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 8px 12px;
+    background: #ffffff;
+    border-radius: 2px;
+    box-shadow: 0 1px 4px -1px rgba(0, 0, 0, 0.3);
+    white-space: nowrap;
+    /* Do not block the map underneath while it is on screen. */
+    pointer-events: none;
+    z-index: 1000;
+}
+
 /* Data load error overlay */
 .loading-overlay {
     position: absolute;

--- a/src/frontend/components/PlanCoordCopy.test.tsx
+++ b/src/frontend/components/PlanCoordCopy.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockMap } from '#test-utils/test-utils';
+import { formatCoords, PlanCoordCopy } from './PlanCoordCopy';
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+// jsdom has no clipboard implementation; install a stub the component can call.
+const installClipboard = () => {
+    Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+    });
+};
+
+// A right-click on the map, as the Maps API delivers it.
+const contextMenuEvent = (lat: number, lng: number) => ({
+    latLng: { lat: () => lat, lng: () => lng },
+    domEvent: { preventDefault: vi.fn() },
+});
+
+// Fire the right-click and let the clipboard promise settle.
+const rightClick = async (map: ReturnType<typeof createMockMap>, event: unknown) => {
+    await act(async () => {
+        map._emit('contextmenu', event);
+    });
+};
+
+describe('formatCoords', () => {
+    it('formats a coordinate pair as a lat/lng array literal', () => {
+        expect(formatCoords(35.123456, 137.987654)).toBe('[35.123456, 137.987654]');
+    });
+
+    it('rounds to 6 decimals and drops trailing zeros', () => {
+        expect(formatCoords(35.1234564999, 137.5)).toBe('[35.123456, 137.5]');
+        expect(formatCoords(36, -0.5)).toBe('[36, -0.5]');
+    });
+});
+
+describe('PlanCoordCopy', () => {
+    beforeEach(() => {
+        writeText.mockReset();
+        writeText.mockResolvedValue(undefined);
+        installClipboard();
+    });
+
+    // Vitest runs without globals, so React Testing Library's auto-cleanup is
+    // not registered; unmount explicitly so pending toast timers are cleared.
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+    });
+
+    it('copies the clicked coordinate and confirms it', async () => {
+        const map = createMockMap();
+        const event = contextMenuEvent(35.123456, 137.987654);
+
+        const { container } = render(<PlanCoordCopy map={map} />);
+        await rightClick(map, event);
+
+        // The format itself is covered above; here it only has to be what the
+        // clipboard and the confirmation carry.
+        expect(writeText).toHaveBeenCalledWith(formatCoords(35.123456, 137.987654));
+        expect(container.textContent).toContain(formatCoords(35.123456, 137.987654));
+        // The copy replaces the browser context menu.
+        expect(event.domEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('reports a failed copy', async () => {
+        const map = createMockMap();
+        writeText.mockRejectedValue(new Error('denied'));
+
+        const { container } = render(<PlanCoordCopy map={map} />);
+        await rightClick(map, contextMenuEvent(35, 137));
+
+        expect(container.textContent).toBe('クリップボードにコピーできませんでした');
+    });
+
+    it('hides the confirmation after a while', async () => {
+        vi.useFakeTimers();
+        const map = createMockMap();
+
+        const { container } = render(<PlanCoordCopy map={map} />);
+        await rightClick(map, contextMenuEvent(35, 137));
+        expect(container.textContent).not.toBe('');
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('gives a second copy its own full display time', async () => {
+        vi.useFakeTimers();
+        const map = createMockMap();
+
+        const { container } = render(<PlanCoordCopy map={map} />);
+        await rightClick(map, contextMenuEvent(35, 137));
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1500);
+        });
+        await rightClick(map, contextMenuEvent(36, 138));
+
+        // The first toast's timer must not carry over and cut this one short.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1500);
+        });
+        expect(container.textContent).toContain(formatCoords(36, 138));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(500);
+        });
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('ignores a right-click without a coordinate', async () => {
+        const map = createMockMap();
+
+        const { container } = render(<PlanCoordCopy map={map} />);
+        await rightClick(map, { latLng: null, domEvent: { preventDefault: vi.fn() } });
+
+        expect(writeText).not.toHaveBeenCalled();
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when map is null', () => {
+        const { container } = render(<PlanCoordCopy map={null} />);
+
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/src/frontend/components/PlanCoordCopy.tsx
+++ b/src/frontend/components/PlanCoordCopy.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Decimal places kept when copying. 6 places is ~11cm on the ground, finer than
+// a point can be picked by eye at any zoom level, so the remaining digits of the
+// clicked coordinate are noise.
+const PRECISION = 6;
+
+// How long the confirmation stays on screen (ms).
+const TOAST_DURATION = 2000;
+
+// Format a coordinate as a `[lat, lng]` literal, ready to paste into the `lat` /
+// `lng` pair of a `data/plans.json` record. `Number()` drops the trailing zeros
+// `toFixed()` adds, keeping `36` rather than `36.000000`.
+export function formatCoords(lat: number, lng: number): string {
+    return `[${Number(lat.toFixed(PRECISION))}, ${Number(lng.toFixed(PRECISION))}]`;
+}
+
+interface PlanCoordCopyProps {
+    map: google.maps.Map | null;
+}
+
+// Copies the coordinate under the cursor to the clipboard on right-click, and
+// confirms with a short-lived message.
+//
+// The browser context menu is suppressed: the copy replaces it, and the menu
+// would open right on top of the confirmation.
+//
+// Only the map itself is listened to, so a right-click landing on a marker does
+// nothing (marker events do not reach the map). That point is the station's
+// recorded position, which is not what anyone is here to copy.
+export function PlanCoordCopy({ map }: PlanCoordCopyProps) {
+    const [message, setMessage] = useState<string | null>(null);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const show = useCallback((text: string) => {
+        setMessage(text);
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+        }
+        timerRef.current = setTimeout(() => setMessage(null), TOAST_DURATION);
+    }, []);
+
+    useEffect(() => {
+        if (!map) {
+            return;
+        }
+
+        const listener = map.addListener('contextmenu', async (event: google.maps.MapMouseEvent) => {
+            if (!event.latLng) {
+                return;
+            }
+            event.domEvent?.preventDefault();
+
+            const text = formatCoords(event.latLng.lat(), event.latLng.lng());
+            try {
+                await navigator.clipboard.writeText(text);
+                show(`${text} をコピーしました`);
+            } catch {
+                show('クリップボードにコピーできませんでした');
+            }
+        });
+
+        return () => {
+            listener.remove();
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+            }
+            // Drop a confirmation left over from the map this effect watched.
+            setMessage(null);
+        };
+    }, [map, show]);
+
+    if (message === null) {
+        return null;
+    }
+    return <div className="plan-toast">{message}</div>;
+}

--- a/src/frontend/components/PlanMap.tsx
+++ b/src/frontend/components/PlanMap.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { loadPlannedStations } from '../planned-stations';
 import type { Category, PlannedStation } from '../types/plan';
+import { PlanCoordCopy } from './PlanCoordCopy';
 import { PlanInfoWindow } from './PlanInfoWindow';
 import { PlanMarkers } from './PlanMarkers';
 import { PlanSidebar } from './PlanSidebar';
@@ -90,6 +91,7 @@ export function PlanMap() {
                     onSelect={setSelected}
                 />
                 <PlanInfoWindow map={map} selected={selected} />
+                <PlanCoordCopy map={map} />
             </div>
         </div>
     );

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -1,6 +1,30 @@
 import { vi } from 'vitest';
 
-// Create mock Google Maps instance with controls and Data layer
+// Event plumbing shared by the mock map and its mock Data layer: `addListener`
+// records the handler (and can unregister it), `_emit` fires what is registered.
+const createListenerRegistry = () => {
+    const listeners: Record<string, ((event: unknown) => void)[]> = {};
+
+    return {
+        addListener: vi.fn((eventName: string, cb: (event: unknown) => void) => {
+            const list = listeners[eventName] ?? [];
+            list.push(cb);
+            listeners[eventName] = list;
+            return {
+                remove: vi.fn(() => {
+                    listeners[eventName] = (listeners[eventName] ?? []).filter((c) => c !== cb);
+                }),
+            };
+        }),
+        _emit: (eventName: string, event: unknown) => {
+            for (const cb of listeners[eventName] ?? []) {
+                cb(event);
+            }
+        },
+    };
+};
+
+// Create mock Google Maps instance with controls, events and Data layer
 export const createMockMap = () => {
     const topLeftControls: HTMLElement[] = [];
     const topCenterControls: HTMLElement[] = [];
@@ -35,19 +59,10 @@ export const createMockMap = () => {
     };
 
     let features: google.maps.Data.Feature[] = [];
-    const listeners: Record<string, ((event: unknown) => void)[]> = {};
+    const dataEvents = createListenerRegistry();
     const data = {
         addGeoJson: vi.fn(),
-        addListener: vi.fn((eventName: string, cb: (event: unknown) => void) => {
-            const list = listeners[eventName] ?? [];
-            list.push(cb);
-            listeners[eventName] = list;
-            return {
-                remove: vi.fn(() => {
-                    listeners[eventName] = (listeners[eventName] ?? []).filter((c) => c !== cb);
-                }),
-            };
-        }),
+        addListener: dataEvents.addListener,
         setStyle: vi.fn(),
         overrideStyle: vi.fn(),
         forEach: vi.fn((cb: (f: google.maps.Data.Feature) => void) => features.forEach(cb)),
@@ -57,17 +72,17 @@ export const createMockMap = () => {
         _setFeatures: (fs: google.maps.Data.Feature[]) => {
             features = fs;
         },
-        _emit: (eventName: string, event: unknown) => {
-            for (const cb of listeners[eventName] ?? []) {
-                cb(event);
-            }
-        },
+        _emit: dataEvents._emit,
     };
+
+    const mapEvents = createListenerRegistry();
 
     return {
         controls,
         data,
-    } as unknown as google.maps.Map & { data: typeof data };
+        addListener: mapEvents.addListener,
+        _emit: mapEvents._emit,
+    } as unknown as google.maps.Map & { data: typeof data; _emit: typeof mapEvents._emit };
 };
 
 // Create mock Google Maps Data Feature


### PR DESCRIPTION
## Summary

Adds a right-click coordinate copy feature to the development plan map. When users right-click on the map, the clicked coordinate is copied to the clipboard in `[lat, lng]` format and a confirmation message is displayed.

## Changes

- **New component `PlanCoordCopy`**: Listens for right-click events on the map, formats coordinates to 6 decimal places, copies them to the clipboard, and displays a transient confirmation toast. The browser context menu is suppressed to avoid overlapping with the confirmation.
  - `formatCoords()` helper formats coordinates as `[lat, lng]` literals, suitable for pasting into `data/plans.json` records
  - Confirmation auto-hides after 2 seconds; subsequent copies reset the timer
  - Gracefully handles clipboard access failures with a localized error message
  - Ignores right-clicks on markers (which don't propagate to the map listener)

- **Comprehensive test suite**: 135 lines of tests covering coordinate formatting, successful/failed copies, timer behavior, multiple consecutive copies, and edge cases (null coordinates, null map)

- **Mock map enhancement**: Extended `createMockMap()` test utility to support event listeners on the map itself (previously only the Data layer had event support), enabling testing of map-level interactions

- **Styling**: Added `.plan-toast` CSS class for the confirmation message—positioned at top center with subtle shadow, non-interactive (`pointer-events: none`) to avoid blocking map interaction

- **Integration**: Imported `PlanCoordCopy` into `PlanMap` component

## Implementation Details

- Coordinates are rounded to 6 decimal places (~11cm precision on the ground), finer than can be picked by eye at any zoom level
- Uses `navigator.clipboard.writeText()` with proper error handling
- Timer cleanup on component unmount and map changes prevents memory leaks
- Japanese localization for confirmation and error messages

https://claude.ai/code/session_01WuM98YSQTVdY5NE5dtdm8L