### PR TITLE
Copy the share URL through the browser Clipboard API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "dependencies": {
                 "@react-oauth/google": "^0.13.5",
                 "cheerio": "^1.2.0",
-                "clipboard": "^2.0.11",
                 "hono": "^4.12.34",
                 "jaconv": "^1.1.2",
                 "jose": "^6.2.7",
@@ -23,7 +22,6 @@
                 "@cloudflare/workers-types": "^5.20260713.1",
                 "@testing-library/react": "^16.3.2",
                 "@types/cheerio": "^1.0.0",
-                "@types/clipboard": "^2.0.10",
                 "@types/google.maps": "^3.65.3",
                 "@types/node": "^24.13.3",
                 "@types/react": "^19.2.18",
@@ -2142,17 +2140,6 @@
                 "cheerio": "*"
             }
         },
-        "node_modules/@types/clipboard": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@types/clipboard/-/clipboard-2.0.10.tgz",
-            "integrity": "sha512-6CIsNdBfOTN92GHhQ0BaGY9KoV4DPH7ynCk5eggSDy3HW7OHLKWJUskL72uoVxl2kZ/XCq28TEgI0HKxLbRxyQ==",
-            "deprecated": "This is a stub types definition. clipboard provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clipboard": "*"
-            }
-        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2799,17 +2786,6 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/clipboard": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-            "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-            "license": "MIT",
-            "dependencies": {
-                "good-listener": "^1.2.2",
-                "select": "^1.1.2",
-                "tiny-emitter": "^2.0.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2941,12 +2917,6 @@
             "engines": {
                 "node": ">=14.16"
             }
-        },
-        "node_modules/delegate": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-            "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-            "license": "MIT"
         },
         "node_modules/dequal": {
             "version": "2.0.3",
@@ -3191,15 +3161,6 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/good-listener": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-            "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-            "license": "MIT",
-            "dependencies": {
-                "delegate": "^3.1.2"
             }
         },
         "node_modules/has-flag": {
@@ -4009,12 +3970,6 @@
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "license": "MIT"
         },
-        "node_modules/select": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-            "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-            "license": "MIT"
-        },
         "node_modules/semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -4135,12 +4090,6 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/tiny-emitter": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
             "license": "MIT"
         },
         "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "dependencies": {
         "@react-oauth/google": "^0.13.5",
         "cheerio": "^1.2.0",
-        "clipboard": "^2.0.11",
         "hono": "^4.12.34",
         "jaconv": "^1.1.2",
         "jose": "^6.2.7",
@@ -51,7 +50,6 @@
         "@cloudflare/workers-types": "^5.20260713.1",
         "@testing-library/react": "^16.3.2",
         "@types/cheerio": "^1.0.0",
-        "@types/clipboard": "^2.0.10",
         "@types/google.maps": "^3.65.3",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",

--- a/src/frontend/components/ShareButton.test.tsx
+++ b/src/frontend/components/ShareButton.test.tsx
@@ -1,31 +1,29 @@
 /**
  * @vitest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthState } from '#shared/auth-types';
-import { createMockMap } from '#test-utils/test-utils';
+import { createMockMap, jsonResponse } from '#test-utils/test-utils';
 import { ShareButton } from './ShareButton';
 
-vi.mock('clipboard', () => ({
-    // biome-ignore lint/complexity/useArrowFunction: stands in for a constructor, so it must be constructible
-    default: vi.fn(function () {
-        return {
-            on: vi.fn(),
-            destroy: vi.fn(),
-        };
-    }),
-}));
+// jsdom has no clipboard implementation; install a stub to copy into.
+const writeText = vi.fn<(text: string) => Promise<void>>();
+Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+});
 
 const mockAuth = vi.hoisted(() => ({
     state: { user: null, sessionToken: null } as AuthState,
 }));
 
-vi.mock('../auth/auth-context', () => ({
-    useAuthManager: () => ({
-        getState: () => mockAuth.state,
-    }),
-}));
+// One manager for the whole file: the real hook hands back the context value, so
+// the identity has to stay stable or effects keyed on it re-run every render.
+vi.mock('../auth/auth-context', () => {
+    const manager = { getState: () => mockAuth.state };
+    return { useAuthManager: () => manager };
+});
 
 Object.defineProperty(global, 'google', {
     value: {
@@ -44,6 +42,7 @@ describe('ShareButton', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        writeText.mockResolvedValue(undefined);
         mockAuth.state = { user: null, sessionToken: null };
         originalLocation = window.location;
 
@@ -57,7 +56,11 @@ describe('ShareButton', () => {
         });
     });
 
+    // Vitest runs without globals, so React Testing Library's auto-cleanup is not
+    // registered; unmount explicitly so the next test starts without a button.
     afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
         Object.defineProperty(window, 'location', {
             value: originalLocation,
             writable: true,
@@ -79,12 +82,7 @@ describe('ShareButton', () => {
 
     it('adds the share button when the user is signed in', async () => {
         mockAuth.state = { user: { sub: 'user-1' }, sessionToken: 'token-abc' };
-        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-            new Response(JSON.stringify({ shareId: 'share-uuid' }), {
-                status: 201,
-                headers: { 'Content-Type': 'application/json' },
-            })
-        );
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ shareId: 'share-uuid' }, 201));
 
         try {
             const mockMap = createMockMap();
@@ -97,6 +95,123 @@ describe('ShareButton', () => {
             const buttonElement = pushCall[0] as HTMLElement;
             expect(buttonElement.className).toBe('share');
             expect(buttonElement.innerText).toBe('シェア');
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('copies the share URL and reports it when the button is clicked', async () => {
+        mockAuth.state = { user: { sub: 'user-1' }, sessionToken: 'token-abc' };
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ shareId: 'share-uuid' }, 201));
+
+        try {
+            const mockMap = createMockMap();
+
+            render(<ShareButton map={mockMap} />);
+
+            // Clicking does nothing until the share id has been fetched, so keep
+            // clicking until the copy goes through.
+            const [button] = mockMap.controls[1].getArray() as HTMLElement[];
+            await waitFor(() => {
+                button.click();
+                expect(writeText).toHaveBeenCalledWith('https://example.com/test?share=share-uuid');
+            });
+
+            await waitFor(() => {
+                const [messageDiv] = mockMap.controls[2].getArray() as HTMLElement[];
+                expect(messageDiv?.className).toBe('share-message');
+                expect(messageDiv?.innerText).toBe('クリップボードにコピーしました。');
+            });
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('reports a failed copy', async () => {
+        mockAuth.state = { user: { sub: 'user-1' }, sessionToken: 'token-abc' };
+        writeText.mockRejectedValue(new Error('denied'));
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ shareId: 'share-uuid' }, 201));
+
+        try {
+            const mockMap = createMockMap();
+
+            render(<ShareButton map={mockMap} />);
+
+            const [button] = mockMap.controls[1].getArray() as HTMLElement[];
+            await waitFor(() => {
+                button.click();
+                expect(writeText).toHaveBeenCalled();
+            });
+
+            await waitFor(() => {
+                const [messageDiv] = mockMap.controls[2].getArray() as HTMLElement[];
+                expect(messageDiv?.innerText).toBe('クリップボードにコピーできませんでした。');
+            });
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('shows a second copy its own message and retires each in turn', async () => {
+        // Let waitFor keep working while the fade-out delay is under our control.
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        mockAuth.state = { user: { sub: 'user-1' }, sessionToken: 'token-abc' };
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ shareId: 'share-uuid' }, 201));
+
+        try {
+            const mockMap = createMockMap();
+
+            render(<ShareButton map={mockMap} />);
+
+            const [button] = mockMap.controls[1].getArray() as HTMLElement[];
+            const messages = mockMap.controls[2];
+            await waitFor(() => {
+                button.click();
+                expect(writeText).toHaveBeenCalled();
+            });
+            // Clicks before the share id lands copy nothing, so exactly one
+            // message follows the click that got through. Its await has to
+            // settle before the message is there to count.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(messages.getArray()).toHaveLength(1);
+
+            // Another copy while the first message is still up stacks its own,
+            // even though the text is identical.
+            button.click();
+            await waitFor(() => expect(messages.getArray()).toHaveLength(2));
+            const stacked = messages.getArray() as HTMLElement[];
+            const oldest = stacked[0];
+            const newest = stacked[stacked.length - 1];
+
+            // Finish only the oldest message's fade-out: that is the one that
+            // must go away, not whichever happens to be last.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(3000);
+            });
+            oldest.dispatchEvent(new Event('transitionend'));
+
+            await waitFor(() => expect(messages.getArray()).not.toContain(oldest));
+            expect(messages.getArray()).toContain(newest);
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('does not copy while the share id is still on its way', async () => {
+        mockAuth.state = { user: { sub: 'user-1' }, sessionToken: 'token-abc' };
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+
+        try {
+            const mockMap = createMockMap();
+
+            render(<ShareButton map={mockMap} />);
+
+            const [button] = mockMap.controls[1].getArray() as HTMLElement[];
+            button.click();
+
+            expect(writeText).not.toHaveBeenCalled();
         } finally {
             fetchSpy.mockRestore();
         }

--- a/src/frontend/components/ShareButton.tsx
+++ b/src/frontend/components/ShareButton.tsx
@@ -1,4 +1,3 @@
-import Clipboard from 'clipboard';
 import { useEffect, useRef, useState } from 'react';
 import { useAuthManager } from '../auth/auth-context';
 import { SharesApiClient } from '../storage';
@@ -34,7 +33,9 @@ interface ShareButtonProps {
 
 export function ShareButton(props: ShareButtonProps) {
     const authManager = useAuthManager();
-    const [lastCopiedAt, setLastCopiedAt] = useState<number | null>(null);
+    // Outcome of the last copy attempt. Wrapped in an object so that repeating
+    // the same message still counts as a new state and shows up again.
+    const [notice, setNotice] = useState<{ text: string } | null>(null);
     const [shareId, setShareId] = useState<string | null>(null);
     const shareIdRef = useRef<string | null>(null);
 
@@ -45,7 +46,7 @@ export function ShareButton(props: ShareButtonProps) {
         shareIdRef.current = shareId;
     }, [shareId]);
 
-    // Pre-fetch (or create) the share id so the click handler can copy synchronously.
+    // Fetch (or create) the share id up front, before a click needs it.
     useEffect(() => {
         if (!isSignedIn) {
             setShareId(null);
@@ -78,25 +79,28 @@ export function ShareButton(props: ShareButtonProps) {
         div.className = 'share';
         div.innerText = 'シェア';
 
-        // Initialize clipboard functionality with direct element reference
-        const clipboard = new Clipboard(div, {
-            text: (_trigger: Element) => {
-                const id = shareIdRef.current;
-                return id ? buildShareURL(id) : '';
-            },
-        });
+        // The share id is pre-fetched, so `writeText` is reached without an
+        // await in between: Safari rejects a clipboard write that lands after
+        // one. Nothing happens while the id is still on its way.
+        const copy = async () => {
+            const id = shareIdRef.current;
+            if (!id) return;
 
-        // Handle copy success with state update
-        clipboard.on('success', () => {
-            setLastCopiedAt(Date.now());
-        });
+            try {
+                await navigator.clipboard.writeText(buildShareURL(id));
+                setNotice({ text: 'クリップボードにコピーしました。' });
+            } catch {
+                setNotice({ text: 'クリップボードにコピーできませんでした。' });
+            }
+        };
+        div.addEventListener('click', copy);
 
         // Add to map controls
         const controls = props.map.controls[google.maps.ControlPosition.TOP_LEFT];
         controls.push(div);
 
         return () => {
-            clipboard.destroy();
+            div.removeEventListener('click', copy);
             const index = controls.getArray().indexOf(div);
             if (index >= 0) {
                 controls.removeAt(index);
@@ -104,9 +108,9 @@ export function ShareButton(props: ShareButtonProps) {
         };
     }, [props.map, isSignedIn]);
 
-    // Handle copy success message display
+    // Handle copy outcome message display
     useEffect(() => {
-        if (!lastCopiedAt || !props.map) return;
+        if (!notice || !props.map) return;
 
         const showMessage = async () => {
             if (!props.map) return;
@@ -114,17 +118,23 @@ export function ShareButton(props: ShareButtonProps) {
             const topControls = props.map.controls[google.maps.ControlPosition.TOP_CENTER];
             const messageDiv = document.createElement('div');
             messageDiv.className = 'share-message';
-            messageDiv.innerText = 'クリップボードにコピーしました。';
+            messageDiv.innerText = notice.text;
 
             topControls.push(messageDiv);
 
             // Fade out after 3 seconds
             await fadeOut(messageDiv, 3000);
-            topControls.pop();
+
+            // Remove this message, not whatever is last: a second copy within
+            // those 3 seconds stacks another one on top.
+            const index = topControls.getArray().indexOf(messageDiv);
+            if (index >= 0) {
+                topControls.removeAt(index);
+            }
         };
 
         showMessage();
-    }, [lastCopiedAt, props.map]);
+    }, [notice, props.map]);
 
     // This component doesn't render anything directly
     return null;


### PR DESCRIPTION
## Summary

Drops the `clipboard` (clipboard.js) dependency from `ShareButton` in favour of `navigator.clipboard.writeText()`, which the development-plan map already uses in `PlanCoordCopy`.

clipboard.js exists to hide the `document.execCommand('copy')` era: a hidden textarea, selection handling, and browser quirks, bound declaratively to a trigger element. With the async Clipboard API a copy is one call, and the library's API (a trigger element plus a click) has no programmatic entry point — which is why the plan map could not use it in the first place.

## Changes

- **`ShareButton`**: a `click` listener on the control element calls `navigator.clipboard.writeText()` directly. The share id is still fetched up front so the write is reached without an `await` in between — Safari rejects a clipboard write that lands after one.
- **Failure is now reported**: a rejected write shows `クリップボードにコピーできませんでした。`, where the library-based version could only report success. The message state holds the text of the last attempt.
- **The confirmation removes its own element** (`indexOf` + `removeAt`) instead of popping the last control, so a second copy within the 3-second fade-out no longer leaves the older message on screen.
- **Dependencies**: `clipboard` and `@types/clipboard` removed (with `delegate`, `good-listener`, `select`, `tiny-emitter` from the lockfile).

## Tests

| Context | Example | Description |
|---|---|---|
| `ShareButton` | `copies the share URL and reports it when the button is clicked` | A click hands the share URL to `navigator.clipboard` and puts the success message into the TOP_CENTER controls |
| `ShareButton` | `reports a failed copy` | A rejected `writeText` surfaces the failure message instead of going unnoticed |
| `ShareButton` | `shows a second copy its own message and retires each in turn` | A second copy stacks its own message even though the text is identical, and a completed fade-out removes that message rather than whichever control is last |
| `ShareButton` | `does not copy while the share id is still on its way` | A click before the share id arrives writes nothing |

The clipboard.js module mock is gone; the tests stub `navigator.clipboard` and exercise the real copy path. Existing fetch mocks now use the `jsonResponse` helper from `src/test-utils`.

`npm run lint`, `npm run typecheck` and the frontend suite (191 tests) pass locally. `src/scripts/generate-stationlist.test.ts` (3 tests) could not run in the session environment: its egress policy denies CONNECT to `www.michi-no-eki.jp:443`. Those tests are untouched by this change and run in CI.

https://claude.ai/code/session_01WuM98YSQTVdY5NE5dtdm8L


---
_Generated by [Claude Code](https://claude.ai/code/session_01WuM98YSQTVdY5NE5dtdm8L)_