### PR TITLE
Skip live michi-no-eki.jp tests on Claude Code on the web

### DIFF
--- a/src/scripts/generate-stationlist.test.ts
+++ b/src/scripts/generate-stationlist.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { getPrefectures, getStationDetails, getStations } from './generate-stationlist';
 
-describe('generate_stationlist', () => {
+// These tests hit michi-no-eki.jp for real, so that a change to the site's
+// markup shows up here instead of in the weekly data update. Claude Code on
+// the web denies egress to the site (403 on CONNECT), so skip them there
+// rather than let every `npm run ci` fail on an unreachable host.
+const isClaudeCodeWeb = process.env.CLAUDE_CODE_REMOTE === 'true';
+
+describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
     describe('getPrefectures', () => {
         it('should fetch and parse prefecture list from michi-no-eki.jp', async () => {
             // Execute the function with real HTTP request


### PR DESCRIPTION
The three tests in generate-stationlist.test.ts fetch michi-no-eki.jp for
real, and Claude Code on the web answers CONNECT to that host with 403. Any
`npm run ci` there failed on the unreachable host regardless of what had
changed, which blocked the pre-commit hook. Skip them when
CLAUDE_CODE_REMOTE is set; GitHub Actions and local checkouts still run
them, so a change to the site's markup is still caught before the weekly
data update.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017hc3k1SYHZXp6YRwPzGSwz