### PR TITLE
Add two Anan, Tokushima records to the development plan ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ data/         生成データ（CSV / GeoJSON）と開発計画マスタ（plans
 
 #### 形式
 
-1 要素 1 駅の JSON 配列（現在 175 件）。キー順は固定で `name` / `pref` / `city` / `status` / `date` / `lat` / `lng` / `urls` / `checked_on`。型は `lat` / `lng` が number または null、`urls` が `{ title, url }`（キー順も固定）の配列、残りは string（空は `""`）。レコード順も固定で `pref` → `city` → `name`（`pref` と `city` は `data/cities.json` の出現順 = 全国地方公共団体コード順。`cities.json` に引き当たらない `city` はその `pref` の末尾に文字列順）。
+1 要素 1 駅の JSON 配列（現在 177 件）。キー順は固定で `name` / `pref` / `city` / `status` / `date` / `lat` / `lng` / `urls` / `checked_on`。型は `lat` / `lng` が number または null、`urls` が `{ title, url }`（キー順も固定）の配列、残りは string（空は `""`）。レコード順も固定で `pref` → `city` → `name`（`pref` と `city` は `data/cities.json` の出現順 = 全国地方公共団体コード順。`cities.json` に引き当たらない `city` はその `pref` の末尾に文字列順）。
 
 - **キー順を固定する**: 差分の安定のためだけでなく、`name` が一意でない（「道の駅 川崎町」が福岡県と宮城県にある）ため、レコードを特定するには `name` の直後に `pref` が来る必要がある
 - **レコード順を固定する**: 順序が動くと差分が壊れる。都道府県順にすると GitHub の編集 UI で目的の駅に当たりが付く（表示順は別物で、`plan-order.ts` が読み込み後に決める）

--- a/data/plans.json
+++ b/data/plans.json
@@ -3100,6 +3100,46 @@
         "checked_on": "2026-01-01"
     },
     {
+        "name": "道の駅 公方の郷なかがわ (リニューアル)",
+        "pref": "徳島県",
+        "city": "阿南市",
+        "status": "開業",
+        "date": "2026-04-11",
+        "lat": 33.9529323,
+        "lng": 134.6678143,
+        "urls": [
+            {
+                "title": "令和７年度「公共施設の再編・最適化」の主な検討状況について",
+                "url": "https://www.city.anan.tokushima.jp/docs/2025120200015/"
+            },
+            {
+                "title": "阿南市の道の駅「公方の郷なかがわ」、11日にリニューアル　産直市に鮮魚などのコーナー新設",
+                "url": "https://www.topics.or.jp/articles/-/1413196"
+            },
+            {
+                "title": "道の駅『公方の郷なかがわ』",
+                "url": "https://www.city.anan.tokushima.jp/docs/2010120900096/"
+            }
+        ],
+        "checked_on": "2026-08-12"
+    },
+    {
+        "name": "道の駅 阿南市",
+        "pref": "徳島県",
+        "city": "阿南市",
+        "status": "凍結",
+        "date": "",
+        "lat": null,
+        "lng": null,
+        "urls": [
+            {
+                "title": "新「道の駅」計画凍結　阿南市",
+                "url": "https://www.topics.or.jp/articles/-/325644"
+            }
+        ],
+        "checked_on": "2026-08-12"
+    },
+    {
         "name": "道の駅 箸蔵",
         "pref": "徳島県",
         "city": "三好市",


### PR DESCRIPTION
## 調査した駅

- **道の駅 公方の郷なかがわ (リニューアル)**（徳島県 阿南市）— 新規追加
- **道の駅 阿南市**（徳島県 阿南市）— 新規追加

いずれも台帳に無かった駅で、今回の調査で追加した。既存レコードの更新はない。

`CLAUDE.md`「開発計画マスタ」のレコード件数（175 件）が実データと合わなくなるため 177 件に更新した。

## 報告事項

`docs/plan-reports.md` への追記はなし。