### PR TITLE
Swap a route marker with the previous one on modifier + right-click

### DIFF
--- a/src/frontend/components/Markers.test.tsx
+++ b/src/frontend/components/Markers.test.tsx
@@ -15,6 +15,7 @@ import {
     Markers,
     resetStyle,
     resolveMarkerClick,
+    swapWithPrevious,
 } from './Markers';
 
 const stations = createMockStations(3);
@@ -183,16 +184,22 @@ describe('Markers', () => {
             expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
         });
 
-        it('ignores Cmd + right-click', () => {
+        it('swaps a numbered marker with the previous one on Cmd + right-click', () => {
             const featureA = createMockFeature('A');
+            const featureB = createMockFeature('B');
+            const featureC = createMockFeature('C');
             const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({
-                multiSelected: [featureA],
+                multiSelected: [featureA, featureB, featureC],
             });
             (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
 
-            mockMap.data._emit('rightclick', buildClickEvent(featureA, 'meta'));
+            mockMap.data._emit('rightclick', buildClickEvent(featureC, 'meta'));
 
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
+            expect(applyUpdater(onMultiSelectChange, [featureA, featureB, featureC])).toEqual([
+                featureA,
+                featureC,
+                featureB,
+            ]);
             expect(onFeatureSelect).not.toHaveBeenCalled();
             expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
         });
@@ -350,6 +357,42 @@ describe('resolveMarkerClick', () => {
             expect(result.cycleStyleOn).toBeUndefined();
             expect(result.multiSelected).toBeUndefined();
         });
+    });
+});
+
+describe('swapWithPrevious', () => {
+    it('swaps the feature with the one numbered just before it', () => {
+        const a = createMockFeature('A');
+        const b = createMockFeature('B');
+        const c = createMockFeature('C');
+
+        expect(swapWithPrevious([a, b, c], c)).toEqual([a, c, b]);
+    });
+
+    it('returns the same array when the feature already holds the first number', () => {
+        const a = createMockFeature('A');
+        const b = createMockFeature('B');
+        const multiSelected = [a, b];
+
+        expect(swapWithPrevious(multiSelected, a)).toBe(multiSelected);
+    });
+
+    it('returns the same array when the feature is not in the route set', () => {
+        const a = createMockFeature('A');
+        const outsider = createMockFeature('B');
+        const multiSelected = [a];
+
+        expect(swapWithPrevious(multiSelected, outsider)).toBe(multiSelected);
+    });
+
+    it('does not mutate the input array', () => {
+        const a = createMockFeature('A');
+        const b = createMockFeature('B');
+        const multiSelected = [a, b];
+
+        swapWithPrevious(multiSelected, b);
+
+        expect(multiSelected).toEqual([a, b]);
     });
 });
 

--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -69,6 +69,22 @@ export function resolveMarkerClick({
     return { selectedFeature: clickedFeature };
 }
 
+// Move `feature` one step towards the head of the route order, trading places
+// with the marker numbered just before it. Returns the input array itself when
+// there is nothing to swap: the feature is not in the route set, or it already
+// holds the first number.
+export function swapWithPrevious(
+    multiSelected: google.maps.Data.Feature[],
+    feature: google.maps.Data.Feature
+): google.maps.Data.Feature[] {
+    const index = multiSelected.indexOf(feature);
+    if (index <= 0) return multiSelected;
+    const next = [...multiSelected];
+    next[index - 1] = feature;
+    next[index] = multiSelected[index - 1];
+    return next;
+}
+
 const styleOptionsFor = (styleId: number): google.maps.Data.StyleOptions => ({
     icon: MARKER_ICONS[styleId],
 });
@@ -235,8 +251,12 @@ export function Markers(props: MarkersProps) {
 
     const onMarkerRightClick = (event: google.maps.Data.MouseEvent) => {
         if (!props.map) return;
-        // Modifier + right-click has no defined meaning; ignore it.
-        if (isModifierPressed(event)) return;
+        // Modifier + right-click reorders the route, as the counterpart to
+        // modifier-click appending a marker at its end.
+        if (isModifierPressed(event)) {
+            props.onMultiSelectChange((prev) => swapWithPrevious(prev, event.feature));
+            return;
+        }
         if (multiSelectedRef.current.length > 0) {
             props.onMultiSelectChange(() => []);
         }


### PR DESCRIPTION
Modifier + right-click on a numbered marker now trades its position with
the marker numbered just before it, so a route can be reordered in place
instead of being cleared and rebuilt. Markers outside the route set and
the marker holding the first number are left untouched.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FeX5mRewAugYFf8B4CxKDb