### PR TITLE
Rename swapWithPrevious to cycleRouteNumber with cycling behavior

### DIFF
--- a/src/frontend/components/Markers.test.tsx
+++ b/src/frontend/components/Markers.test.tsx
@@ -10,12 +10,12 @@ import { MemoryStorage } from '../storage/memory-storage';
 import {
     applyMultiSelection,
     changeStyle,
+    cycleRouteNumber,
     loadRoadStations,
     MAX_ROUTE_SELECTION,
     Markers,
     resetStyle,
     resolveMarkerClick,
-    swapWithPrevious,
 } from './Markers';
 
 const stations = createMockStations(3);
@@ -360,29 +360,37 @@ describe('resolveMarkerClick', () => {
     });
 });
 
-describe('swapWithPrevious', () => {
+describe('cycleRouteNumber', () => {
     it('swaps the feature with the one numbered just before it', () => {
         const a = createMockFeature('A');
         const b = createMockFeature('B');
         const c = createMockFeature('C');
 
-        expect(swapWithPrevious([a, b, c], c)).toEqual([a, c, b]);
+        expect(cycleRouteNumber([a, b, c], c)).toEqual([a, c, b]);
     });
 
-    it('returns the same array when the feature already holds the first number', () => {
+    it('sends the feature holding the first number to the end', () => {
         const a = createMockFeature('A');
         const b = createMockFeature('B');
-        const multiSelected = [a, b];
+        const c = createMockFeature('C');
 
-        expect(swapWithPrevious(multiSelected, a)).toBe(multiSelected);
+        expect(cycleRouteNumber([a, b, c], a)).toEqual([b, c, a]);
+    });
+
+    it('returns the same array when the feature is the only marker in the route set', () => {
+        const a = createMockFeature('A');
+        const multiSelected = [a];
+
+        expect(cycleRouteNumber(multiSelected, a)).toBe(multiSelected);
     });
 
     it('returns the same array when the feature is not in the route set', () => {
         const a = createMockFeature('A');
-        const outsider = createMockFeature('B');
-        const multiSelected = [a];
+        const b = createMockFeature('B');
+        const outsider = createMockFeature('C');
+        const multiSelected = [a, b];
 
-        expect(swapWithPrevious(multiSelected, outsider)).toBe(multiSelected);
+        expect(cycleRouteNumber(multiSelected, outsider)).toBe(multiSelected);
     });
 
     it('does not mutate the input array', () => {
@@ -390,7 +398,8 @@ describe('swapWithPrevious', () => {
         const b = createMockFeature('B');
         const multiSelected = [a, b];
 
-        swapWithPrevious(multiSelected, b);
+        cycleRouteNumber(multiSelected, b);
+        cycleRouteNumber(multiSelected, a);
 
         expect(multiSelected).toEqual([a, b]);
     });

--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -69,16 +69,17 @@ export function resolveMarkerClick({
     return { selectedFeature: clickedFeature };
 }
 
-// Move `feature` one step towards the head of the route order, trading places
-// with the marker numbered just before it. Returns the input array itself when
-// there is nothing to swap: the feature is not in the route set, or it already
-// holds the first number.
-export function swapWithPrevious(
+// Move `feature` one number earlier in the route order, wrapping the first
+// marker around to the end so repeated calls walk a marker through every
+// position. Returns the input array itself when the order cannot change, so the
+// state update bails out instead of re-numbering markers for nothing.
+export function cycleRouteNumber(
     multiSelected: google.maps.Data.Feature[],
     feature: google.maps.Data.Feature
 ): google.maps.Data.Feature[] {
     const index = multiSelected.indexOf(feature);
-    if (index <= 0) return multiSelected;
+    if (index < 0 || multiSelected.length === 1) return multiSelected;
+    if (index === 0) return [...multiSelected.slice(1), feature];
     const next = [...multiSelected];
     next[index - 1] = feature;
     next[index] = multiSelected[index - 1];
@@ -254,7 +255,7 @@ export function Markers(props: MarkersProps) {
         // Modifier + right-click reorders the route, as the counterpart to
         // modifier-click appending a marker at its end.
         if (isModifierPressed(event)) {
-            props.onMultiSelectChange((prev) => swapWithPrevious(prev, event.feature));
+            props.onMultiSelectChange((prev) => cycleRouteNumber(prev, event.feature));
             return;
         }
         if (multiSelectedRef.current.length > 0) {


### PR DESCRIPTION
## Summary

Rename the `swapWithPrevious` function to `cycleRouteNumber` and update its behavior to cycle markers through all positions in the route order, rather than only swapping with the previous marker.

## Changes

- **Function rename**: `swapWithPrevious` → `cycleRouteNumber` in both `Markers.tsx` and `Markers.test.tsx`
- **Behavior update**: When a marker at position 0 is cycled, it now moves to the end of the array instead of returning unchanged
- **Edge case handling**: Clarified that the function returns the input array unchanged only when:
  - The feature is not in the route set, OR
  - The route set contains only one marker
- **Documentation**: Updated JSDoc to reflect the new cycling semantics and explain that repeated calls walk a marker through every position
- **Test updates**: Updated test cases to verify the new cycling behavior, including the case where the first marker wraps to the end

## Implementation Details

The key logic change is in the condition check:
- Old: `if (index <= 0) return multiSelected;` (returned unchanged if at position 0)
- New: `if (index < 0 || multiSelected.length === 1) return multiSelected;` followed by `if (index === 0) return [...multiSelected.slice(1), feature];` (cycles first marker to end)

This enables users to reorder route markers by repeatedly right-clicking with modifier key, cycling each marker through all available positions.

https://claude.ai/code/session_01FE5Gr1dehv3cyti5nJcMgA