### PR TITLE
Add custom route points via Ctrl+double-click on map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ data/         生成データ（GeoJSON）と整備計画マスタ（plans.json�
 - ログイン済み: Workers + D1 と同期する `RemoteStorage`（デバウンス付き）
 - 未ログイン: 空の `MemoryStorage`（ゲストモード、永続化なし）
 
+ルート作成は Ctrl（Cmd）を修飾キーとして駅マーカーを順番に選び、Ctrl + ダブルクリックで駅のない地点にも任意の経由地を落とせる。落とした経由地はドラッグで動かせる（`src/frontend/components/Markers.tsx`）。ルート選択の並びが Google マップのルート URL になる（`src/frontend/components/RouteButton.tsx`）。
+
+- **任意の経由地も Data Layer の Feature にする**: 番号付け・削除・並びの計算が駅マーカーと同じ 1 本の配列で済む。駅データを持たない Feature が混ざるので、駅を前提とする経路は `isCustomPoint()` を見て避ける
+- **ルート URL は駅を「駅名 + 都道府県」、任意の経由地を座標で書く**: 経由地には検索できる名前がない。都道府県を添える理由は `RouteButton.tsx` の `toStopQuery()` のコメントを参照
+- **ダブルクリックズームの抑止はキーの上げ下げに追随させる**: 理由は `Markers.tsx` の `disableDoubleClickZoom` を設定する effect のコメント、押下状態の持ち方は `src/frontend/use-modifier-held.ts` を参照
+
 ### データパイプライン
 
 1. `generate-stationlist.ts` - michi-no-eki.jp を都道府県・駅の階層でたどり、Point Feature の GeoJSON（`data/stations.geojson`）を直接出力する（`cheerio` で HTML 解析、`jaconv` でテキスト正規化）

--- a/src/frontend/components/InfoWindow.test.tsx
+++ b/src/frontend/components/InfoWindow.test.tsx
@@ -64,11 +64,14 @@ describe('InfoWindow', () => {
         render(<InfoWindow selectedFeature={mockFeature as any} map={mockMap} />);
 
         expect(mockInfoWindow.setOptions).toHaveBeenCalledWith({
-            position: { lat: 35.0, lng: 139.0 },
+            position: expect.anything(),
             content: expect.any(HTMLElement),
             headerDisabled: true,
             pixelOffset: expect.any(Object),
         });
+        // The geometry hands back a LatLng, which the InfoWindow takes as is.
+        const { position } = mockInfoWindow.setOptions.mock.calls[0][0] as { position: google.maps.LatLng };
+        expect([position.lat(), position.lng()]).toEqual([35.0, 139.0]);
         expect(mockInfoWindow.open).toHaveBeenCalledWith(mockMap);
     });
 
@@ -83,7 +86,7 @@ describe('InfoWindow', () => {
         render(<InfoWindow selectedFeature={mockFeature as any} map={mockMap} />);
 
         expect(mockInfoWindow.setOptions).toHaveBeenCalledWith({
-            position: { lat: 35.0, lng: 139.0 },
+            position: expect.anything(),
             content: expect.any(HTMLElement),
             headerDisabled: true,
             pixelOffset: expect.any(Object),

--- a/src/frontend/components/Markers.test.tsx
+++ b/src/frontend/components/Markers.test.tsx
@@ -2,15 +2,23 @@
  * @vitest-environment jsdom
  */
 
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockFeature, createMockMap, createMockStations, setupGoogleMapsMock } from '#test-utils/test-utils';
+import {
+    createMockCustomPoint,
+    createMockFeature,
+    createMockLatLng,
+    createMockMap,
+    createMockStations,
+    setupGoogleMapsMock,
+} from '#test-utils/test-utils';
 import { MARKER_ICONS } from '../marker-icons';
 import { MemoryStorage } from '../storage/memory-storage';
 import {
     applyMultiSelection,
     changeStyle,
     cycleRouteNumber,
+    isCustomPoint,
     loadRoadStations,
     MAX_ROUTE_SELECTION,
     Markers,
@@ -29,7 +37,51 @@ const buildClickEvent = (feature: google.maps.Data.Feature, modifier?: 'meta' | 
         } as MouseEvent,
     }) as google.maps.Data.MouseEvent;
 
+const buildMapClickEvent = (modifier?: 'meta' | 'ctrl', lat = 36.5, lng = 140.5): google.maps.MapMouseEvent =>
+    ({
+        latLng: createMockLatLng(lat, lng),
+        domEvent: {
+            metaKey: modifier === 'meta',
+            ctrlKey: modifier === 'ctrl',
+        } as MouseEvent,
+    }) as google.maps.MapMouseEvent;
+
 describe('Markers', () => {
+    const renderMarkers = (
+        overrides: {
+            multiSelected?: google.maps.Data.Feature[];
+            selectedFeature?: google.maps.Data.Feature | null;
+        } = {}
+    ) => {
+        const mockMap = createMockMap();
+        const onMultiSelectChange = vi.fn();
+        const onFeatureSelect = vi.fn();
+        render(
+            <Markers
+                map={mockMap}
+                selectedFeature={overrides.selectedFeature ?? null}
+                onFeatureSelect={onFeatureSelect}
+                multiSelected={overrides.multiSelected ?? []}
+                onMultiSelectChange={onMultiSelectChange}
+                storage={new MemoryStorage()}
+                stations={stations}
+                onStyleChange={() => {}}
+            />
+        );
+        return { mockMap, onMultiSelectChange, onFeatureSelect };
+    };
+
+    // Read back the selection a handler asked for, by running the updater it
+    // handed to onMultiSelectChange against the selection it started from.
+    const applyUpdater = (
+        mock: ReturnType<typeof vi.fn>,
+        prev: google.maps.Data.Feature[]
+    ): google.maps.Data.Feature[] => {
+        expect(mock).toHaveBeenCalledTimes(1);
+        const updater = mock.mock.calls[0][0] as (p: google.maps.Data.Feature[]) => google.maps.Data.Feature[];
+        return updater(prev);
+    };
+
     it('renders nothing to the DOM', () => {
         const mockMap = createMockMap();
         const { container } = render(
@@ -94,39 +146,6 @@ describe('Markers', () => {
         beforeEach(() => {
             setupGoogleMapsMock();
         });
-
-        const renderMarkers = (
-            overrides: {
-                multiSelected?: google.maps.Data.Feature[];
-                selectedFeature?: google.maps.Data.Feature | null;
-            } = {}
-        ) => {
-            const mockMap = createMockMap();
-            const onMultiSelectChange = vi.fn();
-            const onFeatureSelect = vi.fn();
-            render(
-                <Markers
-                    map={mockMap}
-                    selectedFeature={overrides.selectedFeature ?? null}
-                    onFeatureSelect={onFeatureSelect}
-                    multiSelected={overrides.multiSelected ?? []}
-                    onMultiSelectChange={onMultiSelectChange}
-                    storage={new MemoryStorage()}
-                    stations={stations}
-                    onStyleChange={() => {}}
-                />
-            );
-            return { mockMap, onMultiSelectChange, onFeatureSelect };
-        };
-
-        const applyUpdater = (
-            mock: ReturnType<typeof vi.fn>,
-            prev: google.maps.Data.Feature[]
-        ): google.maps.Data.Feature[] => {
-            expect(mock).toHaveBeenCalledTimes(1);
-            const updater = mock.mock.calls[0][0] as (p: google.maps.Data.Feature[]) => google.maps.Data.Feature[];
-            return updater(prev);
-        };
 
         // The branching logic itself is covered by the resolveMarkerClick
         // suite below. This single case exercises the glue layer:
@@ -202,6 +221,127 @@ describe('Markers', () => {
             ]);
             expect(onFeatureSelect).not.toHaveBeenCalled();
             expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
+        });
+
+        it('leaves a custom route point alone on a plain double-click or right-click', () => {
+            const point = createMockCustomPoint();
+            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({ multiSelected: [point] });
+            (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
+
+            mockMap.data._emit('dblclick', buildClickEvent(point));
+            mockMap.data._emit('rightclick', buildClickEvent(point));
+
+            expect(onMultiSelectChange).not.toHaveBeenCalled();
+            expect(onFeatureSelect).not.toHaveBeenCalled();
+            expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('custom route points', () => {
+        beforeEach(() => {
+            setupGoogleMapsMock();
+        });
+
+        // The feature map.data.add() handed back for the double-click.
+        const addedPoint = (mockMap: ReturnType<typeof createMockMap>) =>
+            (mockMap.data.add as ReturnType<typeof vi.fn>).mock.results[0]?.value;
+
+        it('adds a numbered point at the clicked coordinate on Ctrl + double-click', () => {
+            const { mockMap, onMultiSelectChange } = renderMarkers();
+
+            mockMap._emit('dblclick', buildMapClickEvent('ctrl', 36.5, 140.5));
+
+            const point = addedPoint(mockMap);
+            expect(isCustomPoint(point)).toBe(true);
+            expect((point.getGeometry() as google.maps.Data.Point).get().lat()).toBe(36.5);
+            expect(applyUpdater(onMultiSelectChange, [])).toEqual([point]);
+        });
+
+        it('numbers the point after the stations already chosen', () => {
+            const featureA = createMockFeature('A');
+            const featureB = createMockFeature('B');
+            const { mockMap, onMultiSelectChange } = renderMarkers({ multiSelected: [featureA, featureB] });
+
+            mockMap._emit('dblclick', buildMapClickEvent('ctrl'));
+
+            expect(applyUpdater(onMultiSelectChange, [featureA, featureB])).toEqual([
+                featureA,
+                featureB,
+                addedPoint(mockMap),
+            ]);
+        });
+
+        it('lifts a single selection into the route ahead of the new point', () => {
+            const featureA = createMockFeature('A');
+            const { mockMap, onMultiSelectChange } = renderMarkers({ selectedFeature: featureA });
+
+            mockMap._emit('dblclick', buildMapClickEvent('ctrl'));
+
+            expect(applyUpdater(onMultiSelectChange, [])).toEqual([featureA, addedPoint(mockMap)]);
+        });
+
+        it('adds nothing on a double-click without the modifier', () => {
+            const { mockMap, onMultiSelectChange } = renderMarkers();
+
+            mockMap._emit('dblclick', buildMapClickEvent());
+
+            expect(mockMap.data.add).not.toHaveBeenCalled();
+            expect(onMultiSelectChange).not.toHaveBeenCalled();
+        });
+
+        it('adds no point once the route is full', () => {
+            const full = Array.from({ length: MAX_ROUTE_SELECTION }, (_, i) => createMockFeature(`${i}`));
+            const { mockMap, onMultiSelectChange } = renderMarkers({ multiSelected: full });
+
+            mockMap._emit('dblclick', buildMapClickEvent('ctrl'));
+
+            expect(mockMap.data.add).not.toHaveBeenCalled();
+            expect(onMultiSelectChange).not.toHaveBeenCalled();
+        });
+
+        it('keeps the point when the click closes a drag of it', () => {
+            const point = createMockCustomPoint();
+            const { mockMap, onMultiSelectChange } = renderMarkers({ multiSelected: [point] });
+
+            mockMap.data._emit('mousedown', buildClickEvent(point, 'ctrl'));
+            mockMap.data._emit('setgeometry', { feature: point });
+            mockMap.data._emit('click', buildClickEvent(point, 'ctrl'));
+
+            expect(onMultiSelectChange).not.toHaveBeenCalled();
+
+            // The press that starts the next gesture clears the drag.
+            mockMap.data._emit('mousedown', buildClickEvent(point, 'ctrl'));
+            mockMap.data._emit('click', buildClickEvent(point, 'ctrl'));
+
+            expect(onMultiSelectChange).toHaveBeenCalledTimes(1);
+        });
+
+        it('stops the map from zooming while the modifier is held', () => {
+            const { mockMap } = renderMarkers();
+
+            fireEvent.keyDown(window, { key: 'Control', ctrlKey: true });
+            expect(mockMap.setOptions).toHaveBeenLastCalledWith({ disableDoubleClickZoom: true });
+
+            fireEvent.keyUp(window, { key: 'Control', ctrlKey: false });
+            expect(mockMap.setOptions).toHaveBeenLastCalledWith({ disableDoubleClickZoom: false });
+        });
+
+        it('picks the modifier back up from a press when no keydown announced it', () => {
+            const { mockMap } = renderMarkers();
+            // The key went down while another window had focus.
+            fireEvent.mouseDown(window, { ctrlKey: true });
+
+            expect(mockMap.setOptions).toHaveBeenLastCalledWith({ disableDoubleClickZoom: true });
+        });
+
+        it('lets go of the modifier when the window loses focus', () => {
+            const { mockMap } = renderMarkers();
+            fireEvent.keyDown(window, { key: 'Control', ctrlKey: true });
+
+            // The keyup lands in the other window, so only the blur says so.
+            fireEvent.blur(window);
+
+            expect(mockMap.setOptions).toHaveBeenLastCalledWith({ disableDoubleClickZoom: false });
         });
     });
 
@@ -307,6 +447,37 @@ describe('resolveMarkerClick', () => {
             });
 
             expect(result.multiSelected).toEqual(existing);
+        });
+    });
+
+    describe('with a custom route point', () => {
+        it('drops the point out of the route when modifier-clicked', () => {
+            const a = createMockFeature('A');
+            const point = createMockCustomPoint();
+
+            const result = resolveMarkerClick({
+                clickedFeature: point,
+                modifierPressed: true,
+                selectedFeature: null,
+                multiSelected: [a, point],
+            });
+
+            expect(result.multiSelected).toEqual([a]);
+            expect(result.selectedFeature).toBeNull();
+        });
+
+        it('does nothing on a plain click, keeping the route intact', () => {
+            const a = createMockFeature('A');
+            const point = createMockCustomPoint();
+
+            const result = resolveMarkerClick({
+                clickedFeature: point,
+                modifierPressed: false,
+                selectedFeature: null,
+                multiSelected: [a, point],
+            });
+
+            expect(result).toEqual({});
         });
     });
 
@@ -455,6 +626,8 @@ describe('loadRoadStations', () => {
         onMarkerClick: vi.fn(),
         onMarkerDoubleClick: vi.fn(),
         onMarkerRightClick: vi.fn(),
+        onMarkerMouseDown: vi.fn(),
+        onFeatureDragged: vi.fn(),
     });
 
     it('adds the GeoJSON and dispatches click events through the handlers', () => {
@@ -469,10 +642,14 @@ describe('loadRoadStations', () => {
         mockMap.data._emit('click', { feature } as unknown);
         mockMap.data._emit('dblclick', { feature } as unknown);
         mockMap.data._emit('rightclick', { feature } as unknown);
+        mockMap.data._emit('mousedown', { feature } as unknown);
+        mockMap.data._emit('setgeometry', { feature } as unknown);
 
         expect(handlers.onMarkerClick).toHaveBeenCalledTimes(1);
         expect(handlers.onMarkerDoubleClick).toHaveBeenCalledTimes(1);
         expect(handlers.onMarkerRightClick).toHaveBeenCalledTimes(1);
+        expect(handlers.onMarkerMouseDown).toHaveBeenCalledTimes(1);
+        expect(handlers.onFeatureDragged).toHaveBeenCalledTimes(1);
 
         cleanup();
     });
@@ -489,6 +666,8 @@ describe('loadRoadStations', () => {
         ) => google.maps.Data.StyleOptions;
         expect(styleFor(createMockFeature('A'))).toEqual({ icon: MARKER_ICONS[2] });
         expect(styleFor(createMockFeature('B'))).toEqual({ icon: MARKER_ICONS[0] });
+        // A custom route point has no stored style and waits for its number.
+        expect(styleFor(createMockCustomPoint())).toEqual({ visible: false });
     });
 
     it('cleanup detaches every listener so subsequent events are ignored', () => {
@@ -502,10 +681,14 @@ describe('loadRoadStations', () => {
         mockMap.data._emit('click', { feature } as unknown);
         mockMap.data._emit('dblclick', { feature } as unknown);
         mockMap.data._emit('rightclick', { feature } as unknown);
+        mockMap.data._emit('mousedown', { feature } as unknown);
+        mockMap.data._emit('setgeometry', { feature } as unknown);
 
         expect(handlers.onMarkerClick).not.toHaveBeenCalled();
         expect(handlers.onMarkerDoubleClick).not.toHaveBeenCalled();
         expect(handlers.onMarkerRightClick).not.toHaveBeenCalled();
+        expect(handlers.onMarkerMouseDown).not.toHaveBeenCalled();
+        expect(handlers.onFeatureDragged).not.toHaveBeenCalled();
     });
 
     it('cleanup removes every feature from the data layer', () => {
@@ -559,6 +742,33 @@ describe('applyMultiSelection', () => {
         expect(mockMap.data.overrideStyle).toHaveBeenCalledWith(b, {
             icon: MARKER_ICONS[0],
         });
+    });
+
+    it('reveals a custom point with its number and leaves it draggable', () => {
+        const mockMap = createMockMap();
+        const point = createMockCustomPoint();
+        const storage = new MemoryStorage();
+
+        applyMultiSelection(mockMap, [], [point], storage);
+
+        expect(mockMap.data.overrideStyle).toHaveBeenCalledWith(point, {
+            icon: expect.objectContaining({ url: expect.stringContaining('svg') }),
+            visible: true,
+            draggable: true,
+        });
+    });
+
+    it('takes a custom point off the map when it leaves the selection', () => {
+        const mockMap = createMockMap();
+        const a = createMockFeature('A');
+        const point = createMockCustomPoint();
+        const storage = new MemoryStorage();
+
+        applyMultiSelection(mockMap, [a, point], [a], storage);
+
+        expect(mockMap.data.remove).toHaveBeenCalledWith(point);
+        // The station keeps its marker; only its icon goes back to the stored one.
+        expect(mockMap.data.remove).toHaveBeenCalledTimes(1);
     });
 
     it('only re-numbers features still in the selection while resetting the rest', () => {

--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -5,10 +5,28 @@ import type { Storage } from '../storage';
 import * as style from '../style';
 import { getStyle } from '../style';
 import type { StationsGeoJSON } from '../types/geojson';
+import { useModifierHeld } from '../use-modifier-held';
 
 // Google Maps directions support at most 10 stops (origin + destination
 // + 8 waypoints), so the route-selection set is capped just under that bound.
 export const MAX_ROUTE_SELECTION = 9;
+
+// A custom point is a feature the user dropped on the map to route through a
+// place that is not a station. It carries no station data, so a branch that
+// assumes some has to step around it.
+export function isCustomPoint(feature: google.maps.Data.Feature): boolean {
+    return Boolean(feature.getProperty('customPoint'));
+}
+
+// Add a custom route point at `position` and return its feature. It is created
+// hidden: applyMultiSelection reveals it once the selection gives it a number,
+// which keeps it from flashing a station icon in between.
+function addCustomPoint(map: google.maps.Map, position: google.maps.LatLng): google.maps.Data.Feature {
+    return map.data.add({
+        geometry: new google.maps.Data.Point(position),
+        properties: { customPoint: true },
+    });
+}
 
 export interface MarkerClickContext {
     clickedFeature: google.maps.Data.Feature;
@@ -58,6 +76,11 @@ export function resolveMarkerClick({
         };
     }
 
+    // A custom route point has no station behind it, so a plain click has
+    // nothing to open or cycle.
+    if (isCustomPoint(clickedFeature)) {
+        return {};
+    }
     // Plain click clears any in-progress multi-selection before the
     // single-selection logic runs.
     if (multiSelected.length > 0) {
@@ -90,7 +113,16 @@ const styleOptionsFor = (styleId: number): google.maps.Data.StyleOptions => ({
     icon: MARKER_ICONS[styleId],
 });
 
-const isModifierPressed = (event: google.maps.Data.MouseEvent): boolean => {
+// Base style of the data layer: a station shows the icon its stored style id
+// maps to, and a custom route point has none to show.
+const baseStyleFor = (feature: google.maps.Data.Feature, storage: Storage): google.maps.Data.StyleOptions => {
+    if (isCustomPoint(feature)) {
+        return { visible: false };
+    }
+    return styleOptionsFor(getStyle(storage, feature.getProperty('stationId') as string));
+};
+
+export const isModifierPressed = (event: google.maps.MapMouseEvent): boolean => {
     const domEvent = event.domEvent as MouseEvent | undefined;
     return Boolean(domEvent && (domEvent.metaKey || domEvent.ctrlKey));
 };
@@ -115,12 +147,13 @@ interface MarkerHandlers {
     onMarkerClick: (event: google.maps.Data.MouseEvent) => void;
     onMarkerDoubleClick: (event: google.maps.Data.MouseEvent) => void;
     onMarkerRightClick: (event: google.maps.Data.MouseEvent) => void;
+    onMarkerMouseDown: () => void;
+    onFeatureDragged: () => void;
 }
 
-// Load the road-station GeoJSON onto the map's data layer, wire click /
-// dblclick / rightclick listeners, and install the storage-driven style
-// callback. Returns a cleanup that detaches the listeners and removes
-// every feature.
+// Load the road-station GeoJSON onto the map's data layer, wire the marker
+// listeners, and install the storage-driven style callback. Returns a cleanup
+// that detaches the listeners and removes every feature.
 export function loadRoadStations(
     map: google.maps.Map,
     stations: StationsGeoJSON,
@@ -128,18 +161,20 @@ export function loadRoadStations(
     handlers: MarkerHandlers
 ): () => void {
     map.data.addGeoJson(stations);
-    const clickListener = map.data.addListener('click', handlers.onMarkerClick);
-    const doubleClickListener = map.data.addListener('dblclick', handlers.onMarkerDoubleClick);
-    const rightClickListener = map.data.addListener('rightclick', handlers.onMarkerRightClick);
-    map.data.setStyle((feature: google.maps.Data.Feature) => {
-        const stationId = feature.getProperty('stationId') as string;
-        return styleOptionsFor(getStyle(storage, stationId));
-    });
+    const listeners = [
+        map.data.addListener('click', handlers.onMarkerClick),
+        map.data.addListener('dblclick', handlers.onMarkerDoubleClick),
+        map.data.addListener('rightclick', handlers.onMarkerRightClick),
+        map.data.addListener('mousedown', handlers.onMarkerMouseDown),
+        // Dragging a custom point is the only thing that moves a geometry.
+        map.data.addListener('setgeometry', handlers.onFeatureDragged),
+    ];
+    map.data.setStyle((feature: google.maps.Data.Feature) => baseStyleFor(feature, storage));
 
     return () => {
-        clickListener.remove();
-        doubleClickListener.remove();
-        rightClickListener.remove();
+        for (const listener of listeners) {
+            listener.remove();
+        }
         const features: google.maps.Data.Feature[] = [];
         map.data.forEach((f) => {
             features.push(f);
@@ -153,6 +188,10 @@ export function loadRoadStations(
 // Diff `previous` against `next` and reapply icons on the data layer:
 // features no longer selected fall back to their storage-driven icon, while
 // features in `next` receive a 1-based numbered icon matching their position.
+// A custom point exists only as part of a route, so leaving the selection
+// takes its marker off the map rather than restoring a station icon. It is
+// draggable the whole time it is on the map: unlike a station, it stands for
+// nothing but the position the user gave it.
 export function applyMultiSelection(
     map: google.maps.Map,
     previous: google.maps.Data.Feature[],
@@ -160,13 +199,20 @@ export function applyMultiSelection(
     storage: Storage
 ): void {
     for (const feature of previous) {
-        if (!next.includes(feature)) {
-            const stationId = feature.getProperty('stationId') as string;
-            map.data.overrideStyle(feature, styleOptionsFor(getStyle(storage, stationId)));
+        if (next.includes(feature)) continue;
+        if (isCustomPoint(feature)) {
+            map.data.remove(feature);
+            continue;
         }
+        const stationId = feature.getProperty('stationId') as string;
+        map.data.overrideStyle(feature, styleOptionsFor(getStyle(storage, stationId)));
     }
     next.forEach((feature, index) => {
-        map.data.overrideStyle(feature, { icon: numberedMarkerIcon(index + 1) });
+        const numbered: google.maps.Data.StyleOptions = { icon: numberedMarkerIcon(index + 1) };
+        map.data.overrideStyle(
+            feature,
+            isCustomPoint(feature) ? { ...numbered, visible: true, draggable: true } : numbered
+        );
     });
 }
 
@@ -185,6 +231,12 @@ export function Markers(props: MarkersProps) {
     const selectedFeatureRef = useRef<google.maps.Data.Feature | null>(null);
     const multiSelectedRef = useRef<google.maps.Data.Feature[]>(props.multiSelected);
     const storageRef = useRef<Storage>(props.storage);
+    // Set when a drag moved a custom point, cleared by the next press on a
+    // marker. Dragging a point ends with a mouseup on it, and a modifier-click
+    // deletes the point, so the release that finishes a drag must not be taken
+    // for the click that removes what was just positioned.
+    const draggedRef = useRef(false);
+    const modifierHeld = useModifierHeld();
 
     useEffect(() => {
         selectedFeatureRef.current = props.selectedFeature;
@@ -195,10 +247,7 @@ export function Markers(props: MarkersProps) {
     useEffect(() => {
         storageRef.current = props.storage;
         if (!props.map) return;
-        props.map.data.setStyle((feature: google.maps.Data.Feature) => {
-            const stationId = feature.getProperty('stationId') as string;
-            return styleOptionsFor(getStyle(storageRef.current, stationId));
-        });
+        props.map.data.setStyle((feature: google.maps.Data.Feature) => baseStyleFor(feature, storageRef.current));
     }, [props.map, props.storage]);
 
     useEffect(() => {
@@ -207,8 +256,26 @@ export function Markers(props: MarkersProps) {
             onMarkerClick,
             onMarkerDoubleClick,
             onMarkerRightClick,
+            onMarkerMouseDown: () => {
+                draggedRef.current = false;
+            },
+            onFeatureDragged: () => {
+                draggedRef.current = true;
+            },
         });
     }, [props.map, props.stations]);
+
+    useEffect(() => {
+        if (!props.map) return;
+        const listener = props.map.addListener('dblclick', onMapDoubleClick);
+        return () => listener.remove();
+    }, [props.map]);
+
+    // The modifier turns a double-click into "drop a route point here", so the
+    // map must not read the same gesture as a zoom-in while it is held.
+    useEffect(() => {
+        props.map?.setOptions({ disableDoubleClickZoom: modifierHeld });
+    }, [props.map, modifierHeld]);
 
     useEffect(() => {
         if (!props.map) return;
@@ -216,16 +283,7 @@ export function Markers(props: MarkersProps) {
         multiSelectedRef.current = props.multiSelected;
     }, [props.map, props.multiSelected]);
 
-    const onMarkerClick = (event: google.maps.Data.MouseEvent) => {
-        if (!props.map) return;
-
-        const result = resolveMarkerClick({
-            clickedFeature: event.feature,
-            modifierPressed: isModifierPressed(event),
-            selectedFeature: selectedFeatureRef.current,
-            multiSelected: multiSelectedRef.current,
-        });
-
+    const applyClickResult = (result: MarkerClickResult) => {
         if (result.selectedFeature !== undefined) {
             props.onFeatureSelect(result.selectedFeature);
         }
@@ -233,16 +291,53 @@ export function Markers(props: MarkersProps) {
             const { multiSelected } = result;
             props.onMultiSelectChange(() => multiSelected);
         }
-        if (result.cycleStyleOn) {
+        if (result.cycleStyleOn && props.map) {
             changeStyle(props.map, result.cycleStyleOn, storageRef.current);
             props.onStyleChange();
         }
     };
 
+    const onMarkerClick = (event: google.maps.Data.MouseEvent) => {
+        if (!props.map) return;
+        if (draggedRef.current) return;
+
+        applyClickResult(
+            resolveMarkerClick({
+                clickedFeature: event.feature,
+                modifierPressed: isModifierPressed(event),
+                selectedFeature: selectedFeatureRef.current,
+                multiSelected: multiSelectedRef.current,
+            })
+        );
+    };
+
+    // Modifier + double-click on the map drops a custom route point where the
+    // cursor is. The point then takes the number after the ones already chosen,
+    // which is what a modifier-click on a marker created there would have done,
+    // so the click resolver decides the new order too.
+    const onMapDoubleClick = (event: google.maps.MapMouseEvent) => {
+        if (!props.map || !isModifierPressed(event) || !event.latLng) return;
+        // Checked before the point is created so a full route leaves no marker
+        // behind: the resolver would refuse to number it.
+        if (multiSelectedRef.current.length >= MAX_ROUTE_SELECTION) return;
+
+        const feature = addCustomPoint(props.map, event.latLng);
+        applyClickResult(
+            resolveMarkerClick({
+                clickedFeature: feature,
+                modifierPressed: true,
+                selectedFeature: selectedFeatureRef.current,
+                multiSelected: multiSelectedRef.current,
+            })
+        );
+    };
+
     const onMarkerDoubleClick = (event: google.maps.Data.MouseEvent) => {
         if (!props.map) return;
-        // Modifier + double-click has no defined meaning; ignore it.
+        // Modifier + double-click drops a route point, and only the map itself
+        // answers that gesture; on a marker it does nothing.
         if (isModifierPressed(event)) return;
+        if (isCustomPoint(event.feature)) return;
         if (multiSelectedRef.current.length > 0) {
             props.onMultiSelectChange(() => []);
         }
@@ -258,6 +353,7 @@ export function Markers(props: MarkersProps) {
             props.onMultiSelectChange((prev) => cycleRouteNumber(prev, event.feature));
             return;
         }
+        if (isCustomPoint(event.feature)) return;
         if (multiSelectedRef.current.length > 0) {
             props.onMultiSelectChange(() => []);
         }

--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -6,7 +6,7 @@ import { createStorage, type Storage } from '../storage';
 import type { StationsGeoJSON } from '../types/geojson';
 import { InfoWindow } from './InfoWindow';
 import { LoginButton } from './LoginButton';
-import { Markers } from './Markers';
+import { isModifierPressed, Markers } from './Markers';
 import { RouteButton } from './RouteButton';
 import { ShareButton } from './ShareButton';
 import { StationCounter } from './StationCounter';
@@ -84,7 +84,11 @@ export function RoadStationMap() {
     useEffect(() => {
         if (!map) return;
 
-        map.addListener('click', () => {
+        map.addListener('click', (event: google.maps.MapMouseEvent) => {
+            // A modifier-click on the map belongs to the route gesture: it is
+            // the click that precedes the double-click dropping a route point,
+            // and it must not clear the route that point is about to join.
+            if (isModifierPressed(event)) return;
             setFeature(null);
             setMultiSelected([]);
         });

--- a/src/frontend/components/RouteButton.test.tsx
+++ b/src/frontend/components/RouteButton.test.tsx
@@ -4,7 +4,7 @@
 
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockFeature, createMockMap, setupGoogleMapsMock } from '#test-utils/test-utils';
+import { createMockCustomPoint, createMockFeature, createMockMap, setupGoogleMapsMock } from '#test-utils/test-utils';
 import { buildDirectionsURL, RouteButton } from './RouteButton';
 
 describe('buildDirectionsURL', () => {
@@ -22,7 +22,16 @@ describe('buildDirectionsURL', () => {
         expect(url.searchParams.get('destination')).toBe('道の駅 さかい 福井県');
     });
 
-    it('omits the waypoints parameter when only two stations are given', () => {
+    it('writes a custom route point as its coordinate', () => {
+        const features = [createMockCustomPoint(43.7708, 142.365), createMockFeature('2', { name: 'びふか' })];
+
+        const url = new URL(buildDirectionsURL(features));
+
+        expect(url.searchParams.get('origin')).toBe('43.770800,142.365000');
+        expect(url.searchParams.get('destination')).toBe('道の駅 びふか 北海道');
+    });
+
+    it('omits the waypoints parameter when only two stops are given', () => {
         const features = [createMockFeature('1', { name: '三笠' }), createMockFeature('2', { name: 'びふか' })];
 
         const url = new URL(buildDirectionsURL(features));
@@ -30,11 +39,11 @@ describe('buildDirectionsURL', () => {
         expect(url.searchParams.has('waypoints')).toBe(false);
     });
 
-    it('joins intermediate stations into the waypoints parameter with "|"', () => {
+    it('joins intermediate stops into the waypoints parameter with "|"', () => {
         const features = [
             createMockFeature('1', { name: '三笠' }),
             createMockFeature('2', { name: 'スタープラザ 芦別' }),
-            createMockFeature('3', { name: '南ふらの' }),
+            createMockCustomPoint(43.0, 142.0),
             createMockFeature('4', { name: 'びふか' }),
         ];
 
@@ -42,10 +51,10 @@ describe('buildDirectionsURL', () => {
 
         expect(url.searchParams.get('origin')).toBe('道の駅 三笠 北海道');
         expect(url.searchParams.get('destination')).toBe('道の駅 びふか 北海道');
-        expect(url.searchParams.get('waypoints')).toBe('道の駅 スタープラザ 芦別 北海道|道の駅 南ふらの 北海道');
+        expect(url.searchParams.get('waypoints')).toBe('道の駅 スタープラザ 芦別 北海道|43.000000,142.000000');
     });
 
-    it('handles the maximum 9-station route (7 waypoints)', () => {
+    it('handles the maximum 9-stop route (7 waypoints)', () => {
         const features = Array.from({ length: 9 }, (_, i) => createMockFeature(`${i}`, { name: `S${i}` }));
 
         const url = new URL(buildDirectionsURL(features));

--- a/src/frontend/components/RouteButton.tsx
+++ b/src/frontend/components/RouteButton.tsx
@@ -1,23 +1,35 @@
 import { useEffect, useRef } from 'react';
 
+import { isCustomPoint } from './Markers';
+
 interface RouteButtonProps {
     map: google.maps.Map | null;
     multiSelected: google.maps.Data.Feature[];
 }
 
+// Decimal places kept in a custom point's coordinate. 6 places is ~11cm on the
+// ground, past what the point is placed with by eye.
+const PRECISION = 6;
+
+function toStopQuery(feature: google.maps.Data.Feature): string {
+    if (isCustomPoint(feature)) {
+        const position = (feature.getGeometry() as google.maps.Data.Point).get();
+        return `${position.lat().toFixed(PRECISION)},${position.lng().toFixed(PRECISION)}`;
+    }
+    const name = feature.getProperty('name') as string;
+    const prefName = feature.getProperty('prefName') as string;
+    // Some station names are shared by two prefectures ("さかい" sits in both
+    // Ibaraki and Fukui), and the bare name lets Google Maps route to the
+    // wrong one. The prefecture comes from its own field rather than the
+    // address, because a handful of addresses omit it.
+    return `道の駅 ${name} ${prefName}`;
+}
+
 export function buildDirectionsURL(features: google.maps.Data.Feature[]): string {
-    const labels = features.map((feature) => {
-        const name = feature.getProperty('name') as string;
-        const prefName = feature.getProperty('prefName') as string;
-        // Some station names are shared by two prefectures ("さかい" sits in both
-        // Ibaraki and Fukui), and the bare name lets Google Maps route to the
-        // wrong one. The prefecture comes from its own field rather than the
-        // address, because a handful of addresses omit it.
-        return `道の駅 ${name} ${prefName}`;
-    });
-    const origin = labels[0];
-    const destination = labels[labels.length - 1];
-    const waypoints = labels.slice(1, -1);
+    const stops = features.map(toStopQuery);
+    const origin = stops[0];
+    const destination = stops[stops.length - 1];
+    const waypoints = stops.slice(1, -1);
     const url = new URL('https://www.google.com/maps/dir/');
     url.searchParams.set('api', '1');
     url.searchParams.set('origin', origin);

--- a/src/frontend/use-modifier-held.ts
+++ b/src/frontend/use-modifier-held.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+// Track whether the route-editing modifier (Ctrl or Cmd) is currently held, so
+// a caller can read the state before an event arrives carrying it.
+export function useModifierHeld(): boolean {
+    const [held, setHeld] = useState(false);
+
+    useEffect(() => {
+        const sync = (event: KeyboardEvent | MouseEvent) => setHeld(event.ctrlKey || event.metaKey);
+        // Key events stop arriving while another window has focus, so a key
+        // released elsewhere would otherwise stay stuck down.
+        const clear = () => setHeld(false);
+
+        window.addEventListener('keydown', sync);
+        window.addEventListener('keyup', sync);
+        window.addEventListener('blur', clear);
+        // A key pressed while another window had focus is never announced by a
+        // keydown here, so the state is also taken from the mouse, which carries
+        // the modifier on every press. React commits the new state after the
+        // press has been dispatched, which is still in time for the double-click
+        // that press is the first half of.
+        window.addEventListener('mousedown', sync, true);
+
+        return () => {
+            window.removeEventListener('keydown', sync);
+            window.removeEventListener('keyup', sync);
+            window.removeEventListener('blur', clear);
+            window.removeEventListener('mousedown', sync, true);
+        };
+    }, []);
+
+    return held;
+}

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -65,6 +65,15 @@ export const createMockMap = () => {
         addListener: dataEvents.addListener,
         setStyle: vi.fn(),
         overrideStyle: vi.fn(),
+        add: vi.fn((options: google.maps.Data.FeatureOptions) => {
+            const properties = (options.properties ?? {}) as Record<string, unknown>;
+            const feature = {
+                getProperty: (name: string) => properties[name],
+                getGeometry: () => options.geometry,
+            } as unknown as google.maps.Data.Feature;
+            features.push(feature);
+            return feature;
+        }),
         forEach: vi.fn((cb: (f: google.maps.Data.Feature) => void) => features.forEach(cb)),
         remove: vi.fn((f: google.maps.Data.Feature) => {
             features = features.filter((x) => x !== f);
@@ -77,16 +86,35 @@ export const createMockMap = () => {
 
     const mapEvents = createListenerRegistry();
 
+    const setOptions = vi.fn();
+
     return {
         controls,
         data,
+        setOptions,
         addListener: mapEvents.addListener,
         _emit: mapEvents._emit,
-    } as unknown as google.maps.Map & { data: typeof data; _emit: typeof mapEvents._emit };
+    } as unknown as google.maps.Map & {
+        data: typeof data;
+        setOptions: typeof setOptions;
+        _emit: typeof mapEvents._emit;
+    };
 };
 
+// Create a mock google.maps.LatLng, the shape the Maps API hands back from a
+// map event and from a feature's geometry.
+export const createMockLatLng = (lat: number, lng: number) =>
+    ({
+        lat: () => lat,
+        lng: () => lng,
+    }) as google.maps.LatLng;
+
 // Create mock Google Maps Data Feature
-export const createMockFeature = (stationId: string, overrides: Record<string, string> = {}) => {
+export const createMockFeature = (
+    stationId: string,
+    overrides: Record<string, string> = {},
+    position: { lat: number; lng: number } = { lat: 35.0, lng: 139.0 }
+) => {
     const defaultProperties: Record<string, string> = {
         stationId,
         name: `Station ${stationId}`,
@@ -104,10 +132,20 @@ export const createMockFeature = (stationId: string, overrides: Record<string, s
         id: `feature${stationId}`,
         getProperty: (name: string) => properties[name],
         getGeometry: () => ({
-            get: () => ({ lat: 35.0, lng: 139.0 }),
+            get: () => createMockLatLng(position.lat, position.lng),
         }),
     } as unknown as google.maps.Data.Feature;
 };
+
+// Create a mock feature standing for a custom route point: no station data,
+// just the marker property and a position.
+export const createMockCustomPoint = (lat = 36.0, lng = 140.0) =>
+    ({
+        getProperty: (name: string) => (name === 'customPoint' ? true : undefined),
+        getGeometry: () => ({
+            get: () => createMockLatLng(lat, lng),
+        }),
+    }) as unknown as google.maps.Data.Feature;
 
 // Create mock StationsGeoJSON
 export const createMockStations = (count: number, startId = 18786) => ({
@@ -152,6 +190,14 @@ export const setupGoogleMapsMock = () => {
                     public x: number,
                     public y: number
                 ) {}
+            },
+            Data: {
+                Point: class {
+                    constructor(private readonly position: google.maps.LatLng) {}
+                    get() {
+                        return this.position;
+                    }
+                },
             },
         },
     };


### PR DESCRIPTION
Allow users to drop custom waypoints on the map by holding Ctrl (or Cmd) and double-clicking, enabling routes through locations that are not registered stations.

## Summary

This change extends the route-building UI to support arbitrary waypoints. Users can now Ctrl+double-click anywhere on the map to add a numbered stop, which integrates seamlessly with the existing station-selection flow. Custom points are stored as Data Layer features with a marker property, numbered alongside stations, and can be dragged to a new position for as long as they are part of the route.

## Key Changes

- **Custom point creation**: `addCustomPoint()` creates a Data Layer feature carrying a `customPoint` property at the clicked coordinate, which `isCustomPoint()` reads to tell it from a station
- **Modifier key tracking**: New `useModifierHeld()` hook tracks Ctrl/Cmd state across keydown/keyup/blur/mousedown events, so the map's double-click zoom can be switched off before the double-click that drops a point arrives
- **Map double-click handler**: `onMapDoubleClick()` creates a point and routes it through `resolveMarkerClick()` to integrate it into the selection
- **Point lifecycle**: Custom points are hidden until numbered by `applyMultiSelection()`, draggable while on the map, and removed from the map when deselected
- **Drag detection**: `draggedRef` prevents a modifier-click from deleting a point immediately after repositioning it
- **Route formatting**: `toStopQuery()` keeps naming a station by its name and prefecture, and writes a custom point as a `lat,lng` string, which is what a point with no name can be searched by

## Implementation Details

- Custom points carry no station data, so `resolveMarkerClick()` returns early on plain clicks (no-op) but allows modifier-clicks to toggle them out of the route
- `baseStyleFor()` centralizes style logic: stations show their stored icon, custom points start hidden
- A custom point leaving the selection is taken off the map by `applyMultiSelection()`, so the route selection is the only thing that has to be cleared
- Map's `disableDoubleClickZoom` is toggled with the modifier to prevent zoom-in while dropping points
- Test utilities extended with `createMockCustomPoint()`, `createMockLatLng()`, and map event builders

## Added test cases

### `src/frontend/components/Markers.test.tsx`

| Context | Example | 概要 |
|---|---|---|
| `Markers` > `click handlers` | `leaves a custom route point alone on a plain double-click or right-click` | 駅を前提とするスタイル操作が、駅データを持たない Feature に対して走らないこと |
| `Markers` > `custom route points` | `adds a numbered point at the clicked coordinate on Ctrl + double-click` | クリック地点の座標を持つ Feature が作られ、ルートに載ること |
| `Markers` > `custom route points` | `numbers the point after the stations already chosen` | 番号は選択済みの末尾の次（配列の末尾に追加）になること |
| `Markers` > `custom route points` | `lifts a single selection into the route ahead of the new point` | 情報ウィンドウで選択中の駅が 1 番に繰り上がり、任意の経由地が 2 番になること |
| `Markers` > `custom route points` | `adds nothing on a double-click without the modifier` | 修飾キーなしのダブルクリック（＝地図のズーム操作）で Feature が増えないこと |
| `Markers` > `custom route points` | `adds no point once the route is full` | 上限に達しているときは Feature を作る前に諦め、番号の付かないマーカーが地図に残らないこと |
| `Markers` > `custom route points` | `keeps the point when the click closes a drag of it` | ドラッグ終端の mouseup がクリックとして届いても、置き直したばかりの点を削除しないこと |
| `Markers` > `custom route points` | `stops the map from zooming while the modifier is held` | 地点を落とすダブルクリックがズームを兼ねないよう、キーの上げ下げで `disableDoubleClickZoom` が切り替わること |
| `Markers` > `custom route points` | `picks the modifier back up from a press when no keydown announced it` | 他ウィンドウでキーを押したまま戻ったとき、押下状態をマウスイベントから拾い直すこと |
| `Markers` > `custom route points` | `lets go of the modifier when the window loses focus` | 他ウィンドウでキーが離されても押しっぱなし扱いで固まらないこと |
| `resolveMarkerClick` > `with a custom route point` | `drops the point out of the route when modifier-clicked` | 任意の経由地も駅マーカーと同じく修飾キークリックでルートから外れること |
| `resolveMarkerClick` > `with a custom route point` | `does nothing on a plain click, keeping the route intact` | 開く情報も巡回するスタイルも無いので、素のクリックがルートを壊さないこと |
| `applyMultiSelection` | `reveals a custom point with its number and leaves it draggable` | 生成時に隠してある点が、番号付きアイコン・可視・ドラッグ可の 1 回の override で現れること |
| `applyMultiSelection` | `takes a custom point off the map when it leaves the selection` | 選択から外れた任意の経由地はマーカーごと消え、駅は保存済みアイコンに戻るだけであること |

### `src/frontend/components/RouteButton.test.tsx`

| Context | Example | 概要 |
|---|---|---|
| `buildDirectionsURL` | `writes a custom route point as its coordinate` | 名前を持たない経由地だけが `lat,lng` で URL に載り、駅は駅名 + 都道府県のままであること |

https://claude.ai/code/session_01MUfcA1HNUAKdeXrBczczy7