### PR TITLE
Normalize station names by stripping 道の駅 prefix

### DIFF
--- a/src/scripts/generate-stationlist.test.ts
+++ b/src/scripts/generate-stationlist.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { getPrefectures, getStationDetails, getStations } from './generate-stationlist';
+import { getPrefectures, getStationDetails, getStations, stripStationPrefix } from './generate-stationlist';
 
 // These tests hit michi-no-eki.jp for real, so that a change to the site's
 // markup shows up here instead of in the weekly data update. Claude Code on
 // the web denies egress to the site (403 on CONNECT), so skip them there
 // rather than let every `npm run ci` fail on an unreachable host.
 const isClaudeCodeWeb = process.env.CLAUDE_CODE_REMOTE === 'true';
+
+describe('stripStationPrefix', () => {
+    it('should remove a leading 道の駅 prefix', () => {
+        expect(stripStationPrefix('道の駅きたごう')).toBe('きたごう');
+        expect(stripStationPrefix('道の駅「安達」智恵子の里 上り線')).toBe('「安達」智恵子の里 上り線');
+    });
+
+    it('should remove the whitespace following the prefix', () => {
+        expect(stripStationPrefix('道の駅 きたごう')).toBe('きたごう');
+        expect(stripStationPrefix('道の駅　きたごう')).toBe('きたごう');
+    });
+
+    it('should keep 道の駅 that is not a prefix', () => {
+        expect(stripStationPrefix('あ・ら・伊達な道の駅')).toBe('あ・ら・伊達な道の駅');
+        expect(stripStationPrefix('北欧の風 道の駅とうべつ')).toBe('北欧の風 道の駅とうべつ');
+        expect(stripStationPrefix('まきのさんの道の駅・佐川')).toBe('まきのさんの道の駅・佐川');
+    });
+
+    it('should keep a name without the prefix as is', () => {
+        expect(stripStationPrefix('箱根峠')).toBe('箱根峠');
+    });
+});
 
 describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
     describe('getPrefectures', () => {
@@ -90,6 +112,13 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
             expect(lat).toBeLessThan(36);
             expect(lng).toBeGreaterThan(138); // Rough longitude check for Kanagawa
             expect(lng).toBeLessThan(140);
+        });
+
+        it('should drop the 道の駅 prefix the site puts on some station names', async () => {
+            // Station 22061 (Kitagou in Miyazaki) is registered as "道の駅きたごう"
+            const station = await getStationDetails('/stations/views/22061', '54');
+
+            expect(station.name).toBe('きたごう');
         });
     });
 });

--- a/src/scripts/generate-stationlist.ts
+++ b/src/scripts/generate-stationlist.ts
@@ -70,6 +70,12 @@ function normalizeText(text: string | null): string {
     return normalized.trim();
 }
 
+// A few stations are registered on michi-no-eki.jp with a "道の駅" prefix
+// (e.g. "道の駅きたごう") while most are not, so drop it to keep names uniform.
+export function stripStationPrefix(name: string): string {
+    return name.replace(/^道の駅\s*/, '');
+}
+
 export async function* getPrefectures(): AsyncGenerator<Prefecture> {
     const $ = await fetchPage('/');
 
@@ -111,7 +117,7 @@ export async function getStationDetails(stationUri: string, prefId: string): Pro
 
             switch (key) {
                 case '道の駅名':
-                    name = value;
+                    name = stripStationPrefix(value);
                     break;
                 case '所在地':
                     address = value;


### PR DESCRIPTION
## Summary

Some stations on michi-no-eki.jp are registered with a "道の駅" (Michi-no-Eki) prefix in their names (e.g., "道の駅きたごう"), while most are not. This change normalizes station names by removing this prefix to keep names uniform across the dataset.

## Changes

- **Added `stripStationPrefix()` function** in `generate-stationlist.ts` that removes the leading "道の駅" prefix and any following whitespace (both regular and full-width spaces) from station names
- **Applied normalization** in `getStationDetails()` to strip the prefix when extracting the station name from the website
- **Added comprehensive test suite** for `stripStationPrefix()` covering:
  - Basic prefix removal with and without whitespace
  - Preservation of "道の駅" when it appears mid-name (not as a prefix)
  - Pass-through of names without the prefix
- **Added integration test** verifying that station 22061 (Kitagou in Miyazaki) is correctly normalized from "道の駅きたごう" to "きたごう"

## Implementation Details

The regex pattern `/^道の駅\s*/` matches the prefix only at the start of the string and removes any trailing whitespace (including full-width spaces `\u3000`), ensuring consistent normalization while preserving legitimate uses of the term elsewhere in station names.

https://claude.ai/code/session_01EU7bofSthJeSjodG9JXu4q