### PR TITLE
Carry the prefecture name into the route query

### DIFF
--- a/src/frontend/components/RouteButton.test.tsx
+++ b/src/frontend/components/RouteButton.test.tsx
@@ -8,15 +8,18 @@ import { createMockFeature, createMockMap, setupGoogleMapsMock } from '#test-uti
 import { buildDirectionsURL, RouteButton } from './RouteButton';
 
 describe('buildDirectionsURL', () => {
-    it('uses "道の駅 <name>" labels for origin and destination', () => {
-        const features = [createMockFeature('1', { name: '三笠' }), createMockFeature('2', { name: 'びふか' })];
+    it('appends the prefecture, telling two stations sharing a name apart', () => {
+        const features = [
+            createMockFeature('1', { name: 'さかい', prefName: '茨城県' }),
+            createMockFeature('2', { name: 'さかい', prefName: '福井県' }),
+        ];
 
         const url = new URL(buildDirectionsURL(features));
 
         expect(url.origin + url.pathname).toBe('https://www.google.com/maps/dir/');
         expect(url.searchParams.get('api')).toBe('1');
-        expect(url.searchParams.get('origin')).toBe('道の駅 三笠');
-        expect(url.searchParams.get('destination')).toBe('道の駅 びふか');
+        expect(url.searchParams.get('origin')).toBe('道の駅 さかい 茨城県');
+        expect(url.searchParams.get('destination')).toBe('道の駅 さかい 福井県');
     });
 
     it('omits the waypoints parameter when only two stations are given', () => {
@@ -37,9 +40,9 @@ describe('buildDirectionsURL', () => {
 
         const url = new URL(buildDirectionsURL(features));
 
-        expect(url.searchParams.get('origin')).toBe('道の駅 三笠');
-        expect(url.searchParams.get('destination')).toBe('道の駅 びふか');
-        expect(url.searchParams.get('waypoints')).toBe('道の駅 スタープラザ 芦別|道の駅 南ふらの');
+        expect(url.searchParams.get('origin')).toBe('道の駅 三笠 北海道');
+        expect(url.searchParams.get('destination')).toBe('道の駅 びふか 北海道');
+        expect(url.searchParams.get('waypoints')).toBe('道の駅 スタープラザ 芦別 北海道|道の駅 南ふらの 北海道');
     });
 
     it('handles the maximum 9-station route (7 waypoints)', () => {
@@ -47,16 +50,16 @@ describe('buildDirectionsURL', () => {
 
         const url = new URL(buildDirectionsURL(features));
 
-        expect(url.searchParams.get('origin')).toBe('道の駅 S0');
-        expect(url.searchParams.get('destination')).toBe('道の駅 S8');
+        expect(url.searchParams.get('origin')).toBe('道の駅 S0 北海道');
+        expect(url.searchParams.get('destination')).toBe('道の駅 S8 北海道');
         expect(url.searchParams.get('waypoints')?.split('|')).toEqual([
-            '道の駅 S1',
-            '道の駅 S2',
-            '道の駅 S3',
-            '道の駅 S4',
-            '道の駅 S5',
-            '道の駅 S6',
-            '道の駅 S7',
+            '道の駅 S1 北海道',
+            '道の駅 S2 北海道',
+            '道の駅 S3 北海道',
+            '道の駅 S4 北海道',
+            '道の駅 S5 北海道',
+            '道の駅 S6 北海道',
+            '道の駅 S7 北海道',
         ]);
     });
 });

--- a/src/frontend/components/RouteButton.tsx
+++ b/src/frontend/components/RouteButton.tsx
@@ -8,7 +8,12 @@ interface RouteButtonProps {
 export function buildDirectionsURL(features: google.maps.Data.Feature[]): string {
     const labels = features.map((feature) => {
         const name = feature.getProperty('name') as string;
-        return `道の駅 ${name}`;
+        const prefName = feature.getProperty('prefName') as string;
+        // Some station names are shared by two prefectures ("さかい" sits in both
+        // Ibaraki and Fukui), and the bare name lets Google Maps route to the
+        // wrong one. The prefecture comes from its own field rather than the
+        // address, because a handful of addresses omit it.
+        return `道の駅 ${name} ${prefName}`;
     });
     const origin = labels[0];
     const destination = labels[labels.length - 1];

--- a/src/frontend/types/geojson.ts
+++ b/src/frontend/types/geojson.ts
@@ -6,6 +6,7 @@ export interface StationProperties {
     uri: string;
     mapcode: string;
     prefId: string;
+    prefName: string;
 }
 
 export interface StationFeature {

--- a/src/lib/station-geojson.test.ts
+++ b/src/lib/station-geojson.test.ts
@@ -5,6 +5,7 @@ import type { Station } from './types';
 function station(overrides: Partial<Station> = {}): Station {
     return {
         prefId: '23',
+        prefName: '神奈川県',
         stationId: '19150',
         name: '箱根峠',
         address: '250-0521 神奈川県足柄下郡箱根町箱根381-22',
@@ -30,6 +31,7 @@ describe('toFeature', () => {
 
         expect(feature.properties).toEqual({
             prefId: '23',
+            prefName: '神奈川県',
             stationId: '19150',
             name: '箱根峠',
             address: '250-0521 神奈川県足柄下郡箱根町箱根381-22',

--- a/src/lib/station-geojson.ts
+++ b/src/lib/station-geojson.ts
@@ -19,6 +19,7 @@ interface StationFeature {
     };
     properties: {
         prefId: string;
+        prefName: string;
         stationId: string;
         name: string;
         address: string;
@@ -41,6 +42,7 @@ export function toFeature(station: Station): StationFeature {
         },
         properties: {
             prefId: station.prefId,
+            prefName: station.prefName,
             stationId: station.stationId,
             name: station.name,
             address: station.address,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 export interface Station {
     prefId: string;
+    prefName: string;
     stationId: string;
     name: string;
     address: string;

--- a/src/scripts/generate-stationlist.test.ts
+++ b/src/scripts/generate-stationlist.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getPrefectures, getStationDetails, getStations, stripStationPrefix } from './generate-stationlist';
+import {
+    getPrefectures,
+    getStationDetails,
+    getStations,
+    normalizePrefectureName,
+    stripStationPrefix,
+} from './generate-stationlist';
 
 // These tests hit michi-no-eki.jp for real, so that a change to the site's
 // markup shows up here instead of in the weekly data update. Claude Code on
@@ -29,6 +35,24 @@ describe('stripStationPrefix', () => {
     });
 });
 
+describe('normalizePrefectureName', () => {
+    it('should append 県 to an ordinary prefecture', () => {
+        expect(normalizePrefectureName('茨城')).toBe('茨城県');
+        expect(normalizePrefectureName('神奈川')).toBe('神奈川県');
+        expect(normalizePrefectureName('沖縄')).toBe('沖縄県');
+    });
+
+    it('should give 東京 its 都 and 大阪 / 京都 their 府', () => {
+        expect(normalizePrefectureName('東京')).toBe('東京都');
+        expect(normalizePrefectureName('大阪')).toBe('大阪府');
+        expect(normalizePrefectureName('京都')).toBe('京都府');
+    });
+
+    it('should leave 北海道 alone', () => {
+        expect(normalizePrefectureName('北海道')).toBe('北海道');
+    });
+});
+
 describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
     describe('getPrefectures', () => {
         it('should fetch and parse prefecture list from michi-no-eki.jp', async () => {
@@ -42,11 +66,11 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
             const prefectureNames = prefectures.map((p) => p.name);
 
             // Check if we have some expected prefectures
-            // Note: Prefecture names on the site don't include suffixes like '都', '府', '県'
+            // Note: the site omits suffixes like '都', '府', '県'; getPrefectures puts them back
             expect(prefectureNames).toContain('北海道');
-            expect(prefectureNames).toContain('東京');
-            expect(prefectureNames).toContain('大阪');
-            expect(prefectureNames).toContain('沖縄');
+            expect(prefectureNames).toContain('東京都');
+            expect(prefectureNames).toContain('大阪府');
+            expect(prefectureNames).toContain('沖縄県');
         });
     });
 
@@ -55,7 +79,7 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
             // Use Iwate prefecture (ID: 13) to test pagination functionality
             const iwate = {
                 id: '13',
-                name: '岩手',
+                name: '岩手県',
                 uri: '/stations/search/13/all/all',
             };
 
@@ -65,9 +89,10 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
             // Iwate has exactly 39 stations
             expect(stations).toHaveLength(39);
 
-            // Verify all stations have the correct prefecture ID
+            // Verify all stations have the correct prefecture
             stations.forEach((station) => {
                 expect(station.prefId).toBe('13');
+                expect(station.prefName).toBe('岩手県');
             });
 
             // Check for known stations in Iwate
@@ -81,12 +106,13 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
         it('should fetch and parse station details from a specific station page', async () => {
             // Test with station ID 19150 (Hakone-toge in Kanagawa)
             const stationUri = '/stations/views/19150';
-            const prefId = '23'; // Kanagawa
+            const kanagawa = { id: '23', name: '神奈川県' };
 
-            const station = await getStationDetails(stationUri, prefId);
+            const station = await getStationDetails(stationUri, kanagawa);
 
-            // Verify prefecture ID (passed as parameter)
+            // Verify prefecture (passed as parameter)
             expect(station.prefId).toBe('23');
+            expect(station.prefName).toBe('神奈川県');
 
             // Verify station ID (extracted from URI)
             expect(station.stationId).toBe('19150');
@@ -114,7 +140,7 @@ describe.skipIf(isClaudeCodeWeb)('generate_stationlist', () => {
 
         it('should drop the 道の駅 prefix the site puts on some station names', async () => {
             // Station 22061 (Kitagou in Miyazaki) is registered as "道の駅きたごう"
-            const station = await getStationDetails('/stations/views/22061', '54');
+            const station = await getStationDetails('/stations/views/22061', { id: '54', name: '宮崎県' });
 
             expect(station.name).toBe('きたごう');
         });

--- a/src/scripts/generate-stationlist.ts
+++ b/src/scripts/generate-stationlist.ts
@@ -9,7 +9,7 @@ const BASEURI = 'https://www.michi-no-eki.jp/';
 const FETCH_INTERVAL = 1000; // 1 second in milliseconds
 const STATION_FILENAME = 'data/stations.geojson';
 
-interface Prefecture {
+export interface Prefecture {
     id: string;
     name: string;
     uri: string;
@@ -76,6 +76,22 @@ export function stripStationPrefix(name: string): string {
     return name.replace(/^道の駅\s*/, '');
 }
 
+// The site lists prefectures without their suffix ("東京", "岩手"), but a bare
+// name is not unambiguous as a place: "茨城" is also a town inside Ibaraki.
+// Restore the suffix so the name stands on its own.
+export function normalizePrefectureName(name: string): string {
+    if (name === '北海道') {
+        return name;
+    }
+    if (name === '東京') {
+        return '東京都';
+    }
+    if (name === '大阪' || name === '京都') {
+        return `${name}府`;
+    }
+    return `${name}県`;
+}
+
 export async function* getPrefectures(): AsyncGenerator<Prefecture> {
     const $ = await fetchPage('/');
 
@@ -86,12 +102,12 @@ export async function* getPrefectures(): AsyncGenerator<Prefecture> {
 
         if (uri) {
             const prefId = uri.split('/')[3];
-            yield { id: prefId, name, uri };
+            yield { id: prefId, name: normalizePrefectureName(name), uri };
         }
     }
 }
 
-export async function getStationDetails(stationUri: string, prefId: string): Promise<Station> {
+export async function getStationDetails(stationUri: string, pref: Pick<Prefecture, 'id' | 'name'>): Promise<Station> {
     const uri = getUrl(stationUri);
     const stationId = uri.split('/').pop() || '';
 
@@ -152,7 +168,8 @@ export async function getStationDetails(stationUri: string, prefId: string): Pro
     }
 
     return {
-        prefId,
+        prefId: pref.id,
+        prefName: pref.name,
         stationId,
         name,
         address,
@@ -178,7 +195,7 @@ export async function* getStations(pref: Prefecture): AsyncGenerator<Station> {
         if (!href) continue;
 
         try {
-            const station = await getStationDetails(href, pref.id);
+            const station = await getStationDetails(href, pref);
             yield station;
         } catch (error) {
             const uri = getUrl(href);

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -95,6 +95,7 @@ export const createMockFeature = (stationId: string, overrides: Record<string, s
         uri: `https://example.com/station-${stationId}`,
         mapcode: '123 456*78',
         prefId: '01',
+        prefName: '北海道',
     };
 
     const properties = { ...defaultProperties, ...overrides };
@@ -125,6 +126,7 @@ export const createMockStations = (count: number, startId = 18786) => ({
             uri: '',
             mapcode: '',
             prefId: '01',
+            prefName: '北海道',
         },
     })),
 });


### PR DESCRIPTION
Five station names are shared by two prefectures ("さかい" is registered in
both Ibaraki and Fukui), and buildDirectionsURL passed only "道の駅 <name>",
so Google Maps was free to route to the wrong one. The prefecture cannot be
read off the address: five stations are registered without one, and one of
them carries "静岡藤枝市" in place of the prefecture.

The scraper already fetched prefecture names and dropped them before writing
the data, so carry them through instead: getPrefectures now restores the
suffix the site omits ("東京" -> "東京都"), getStationDetails takes the
prefecture rather than its id alone, and prefName reaches the GeoJSON
properties. Route labels become "道の駅 さかい 茨城県", which resolves to a
single station.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012GdAo9v1xBXrjShNuDD1Us