### PR TITLE
Update roadside station plan records from web research

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -2553,11 +2553,11 @@
         "lng": 138.2705173,
         "urls": [
             {
-                "title": "https://www.city.fujieda.shizuoka.jp/soshiki/kankyosuido/cleancenter/keikaku_torikumi/21065.html",
+                "title": "藤枝市「道の駅（仮）かりやど」基本構想を策定しました",
                 "url": "https://www.city.fujieda.shizuoka.jp/soshiki/kankyosuido/cleancenter/keikaku_torikumi/21065.html"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 ゆとりえせとや",
@@ -2589,11 +2589,11 @@
         "lng": 138.9066439,
         "urls": [
             {
-                "title": "https://www.city.susono.shizuoka.jp/material/files/group/12/2023070603.pdf",
-                "url": "https://www.city.susono.shizuoka.jp/material/files/group/12/2023070603.pdf"
+                "title": "道の駅整備事業",
+                "url": "https://www.city.susono.shizuoka.jp/shisei/9/19571.html"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 そらっと牧之原",
@@ -2631,17 +2631,17 @@
         "name": "道の駅 犬山市",
         "pref": "愛知県",
         "city": "犬山市",
-        "status": "計画中",
+        "status": "中止",
         "date": "",
         "lat": 35.366213,
         "lng": 136.9491066,
         "urls": [
             {
-                "title": "https://www.city.inuyama.aichi.jp/shisei/keikaku/1005922/1005698/index.html",
+                "title": "五郎丸東一丁目地区まちづくり",
                 "url": "https://www.city.inuyama.aichi.jp/shisei/keikaku/1005922/1005698/index.html"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 マチテラス日進",
@@ -2677,7 +2677,7 @@
                 "url": "https://www.town.meiwa.mie.jp/material/files/group/45/toshimasusoan.pdf"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 守山市",
@@ -2693,11 +2693,11 @@
                 "url": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001349092.pdf"
             },
             {
-                "title": "https://www.city.moriyama.lg.jp/machikankyobousai/1002072/1002180/1008292.html",
+                "title": "「環境保全と活性化を両輪とした道の駅」構想案に係るパブリックコメントの手続結果",
                 "url": "https://www.city.moriyama.lg.jp/machikankyobousai/1002072/1002180/1008292.html"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 テオテラスいで",
@@ -2709,15 +2709,15 @@
         "lng": 135.8149913,
         "urls": [
             {
-                "title": "https://www.town.ide.kyoto.jp/soshiki/soumu/shintyosya/1571375864921.html",
-                "url": "https://www.town.ide.kyoto.jp/soshiki/soumu/shintyosya/1571375864921.html"
+                "title": "テオテラスいで",
+                "url": "https://www.town.ide.kyoto.jp/iju/go/4387.html"
             },
             {
-                "title": "https://ja.wikipedia.org/wiki/%E3%83%86%E3%82%AA%E3%83%86%E3%83%A9%E3%82%B9%E3%81%84%E3%81%A7",
+                "title": "テオテラスいで - Wikipedia",
                 "url": "https://ja.wikipedia.org/wiki/%E3%83%86%E3%82%AA%E3%83%86%E3%83%A9%E3%82%B9%E3%81%84%E3%81%A7"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 富田林市",
@@ -2729,15 +2729,11 @@
         "lng": 135.6085583,
         "urls": [
             {
-                "title": "http://tahiramayumi.com/2022/10/",
-                "url": "http://tahiramayumi.com/2022/10/"
-            },
-            {
                 "title": "https://www.city.tondabayashi.lg.jp/uploaded/attachment/79135.pdf",
                 "url": "https://www.city.tondabayashi.lg.jp/uploaded/attachment/79135.pdf"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 豊能町",
@@ -2769,11 +2765,11 @@
         "lng": 135.2911829,
         "urls": [
             {
-                "title": "https://waryaji.com/1-2770/",
+                "title": "【田尻町】「農の駅」整備や観光農園の集約を柱とする新構想案を策定　農業・漁業・観光の連携強化へ",
                 "url": "https://waryaji.com/1-2770/"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 姫路",
@@ -2804,6 +2800,30 @@
         "checked_on": "2026-08-11"
     },
     {
+        "name": "道の駅 高田屋嘉兵衛公園",
+        "pref": "兵庫県",
+        "city": "洲本市",
+        "status": "計画中",
+        "date": "",
+        "lat": 34.4161941,
+        "lng": 134.7918969,
+        "urls": [
+            {
+                "title": "淡路島洲本で「道の駅」開業に向け地元農産物を使った商品を開発したい",
+                "url": "https://readyfor.jp/projects/97258"
+            },
+            {
+                "title": "高田屋嘉兵衛公園の道の駅整備説明会｜洲本市が7月4日に五色庁舎で開催",
+                "url": "https://harimap.com/sumoto-takadaya-michinoeki-briefing-20260704/"
+            },
+            {
+                "title": "新たな洲本市西海岸の観光拠点「高田屋嘉兵衛公園道の駅」施設整備の基本設計が完成！",
+                "url": "https://kisspress.jp/news/61686/"
+            }
+        ],
+        "checked_on": "2026-08-18"
+    },
+    {
         "name": "道の駅 小野市",
         "pref": "兵庫県",
         "city": "小野市",
@@ -2813,11 +2833,11 @@
         "lng": 134.9541667,
         "urls": [
             {
-                "title": "https://www.city.ono.hyogo.jp/soshikikarasagasu/somubu_zaiseika/gyomuannai/2/2/11375.html",
+                "title": "令和5年度予算",
                 "url": "https://www.city.ono.hyogo.jp/soshikikarasagasu/somubu_zaiseika/gyomuannai/2/2/11375.html"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 よかわ",
@@ -2890,30 +2910,6 @@
             }
         ],
         "checked_on": "2026-08-11"
-    },
-    {
-        "name": "道の駅 高田屋嘉兵衛公園",
-        "pref": "兵庫県",
-        "city": "淡路市",
-        "status": "計画中",
-        "date": "",
-        "lat": 34.4161941,
-        "lng": 134.7918969,
-        "urls": [
-            {
-                "title": "https://readyfor.jp/projects/97258",
-                "url": "https://readyfor.jp/projects/97258"
-            },
-            {
-                "title": "https://www.city.sumoto.lg.jp/uploaded/attachment/15045.pdf",
-                "url": "https://www.city.sumoto.lg.jp/uploaded/attachment/15045.pdf"
-            },
-            {
-                "title": "https://kisspress.jp/news/61686/",
-                "url": "https://kisspress.jp/news/61686/"
-            }
-        ],
-        "checked_on": "2026-01-01"
     },
     {
         "name": "道の駅 クロスウェイなかまち",

--- a/data/plans.json
+++ b/data/plans.json
@@ -2804,7 +2804,7 @@
         "pref": "兵庫県",
         "city": "洲本市",
         "status": "計画中",
-        "date": "",
+        "date": "2029年度",
         "lat": 34.4161941,
         "lng": 134.7918969,
         "urls": [
@@ -2813,12 +2813,16 @@
                 "url": "https://readyfor.jp/projects/97258"
             },
             {
-                "title": "高田屋嘉兵衛公園の道の駅整備説明会｜洲本市が7月4日に五色庁舎で開催",
-                "url": "https://harimap.com/sumoto-takadaya-michinoeki-briefing-20260704/"
+                "title": "(仮称)高田屋嘉兵衛公園「道の駅」整備にかかる説明会の開催について",
+                "url": "https://www.city.sumoto.lg.jp/soshiki/16/36532.html"
             },
             {
                 "title": "新たな洲本市西海岸の観光拠点「高田屋嘉兵衛公園道の駅」施設整備の基本設計が完成！",
                 "url": "https://kisspress.jp/news/61686/"
+            },
+            {
+                "title": "開業が大幅遅れの道の駅は事業費２５億円…初の住民説明会で発表、参加者らは「来る仕掛けが必要」「地元ゆかりの偉人コーナーを」と要望",
+                "url": "https://www.yomiuri.co.jp/local/kansai/news/20260708-GYO1T00098/"
             }
         ],
         "checked_on": "2026-08-18"


### PR DESCRIPTION
## 調査した駅

`checked_on` が古い順で 11〜20 件目を調査した（値が動かなかった駅も含む）。1〜10 件目は #376 で調査中。

| 駅 | 都道府県 |
|---|---|
| 道の駅 かりやど | 静岡県 |
| 道の駅 ふじさんすその | 静岡県 |
| 道の駅 犬山市 | 愛知県 |
| 道の駅 明和町 | 三重県 |
| 道の駅 守山市 | 滋賀県 |
| 道の駅 テオテラスいで | 京都府 |
| 道の駅 富田林市 | 大阪府 |
| 道の駅 田尻町 | 大阪府 |
| 道の駅 小野市 | 兵庫県 |
| 道の駅 高田屋嘉兵衛公園 | 兵庫県 |

## 報告事項

`docs/plan-reports.md` への追記はなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)