### PR TITLE
Refresh the next 10 least recently checked plan records

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -13,7 +13,7 @@
                 "url": "https://www.city.asahikawa.hokkaido.jp/10013/10014/d078561.html"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 しらぬか恋問 (リニューアル)",
@@ -49,7 +49,7 @@
                 "url": "https://www.hokkaido-airports.co.jp/pdf/business_plan2020-2024.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 275つきがた",
@@ -89,7 +89,7 @@
                 "url": "https://www.town.oshamambe.lg.jp/uploaded/attachment/5029.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅かもめ島",
@@ -119,9 +119,13 @@
             {
                 "title": "https://www.hokkaido-np.co.jp/article/1305345/",
                 "url": "https://www.hokkaido-np.co.jp/article/1305345/"
+            },
+            {
+                "title": "江差・道の駅、開業着実に　建設工事の安全祈願祭",
+                "url": "https://www.hokkaido-np.co.jp/article/1313196/"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅ニセコビュープラザ (再整備)",
@@ -139,9 +143,13 @@
             {
                 "title": "https://www.town.niseko.lg.jp/information/3810/",
                 "url": "https://www.town.niseko.lg.jp/information/3810/"
+            },
+            {
+                "title": "道の駅ニセコ、建て替え再検討　町議会で町長",
+                "url": "https://www.hokkaido-np.co.jp/article/1326289/"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 かかしの郷 きょうわ",
@@ -181,7 +189,7 @@
                 "url": "https://www.tomonoba.co.jp/kyowa_michinoeki/"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 ふるびら",
@@ -231,9 +239,13 @@
             {
                 "title": "https://e-kensin.net/n/n7c3f4686e956",
                 "url": "https://e-kensin.net/n/n7c3f4686e956"
+            },
+            {
+                "title": "余市「新道の駅」検討に民間視点　後志道IC付近、整備や運営手法巡り14日から市場調査",
+                "url": "https://www.hokkaido-np.co.jp/article/1260984/"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 上富良野町",
@@ -253,7 +265,7 @@
                 "url": "https://www.town.kamifurano.hokkaido.jp/contents/02kikaku/0210sinko/fukugokyotenplan-proposal/kyoten_kiso.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 中富良野町",
@@ -3661,7 +3673,7 @@
                 "url": "http://www.town.minamitane.kagoshima.jp/assets/files/pdf/kikaku/20250321_paburikkukomennto.pdf"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 徳之島",
@@ -3701,7 +3713,7 @@
                 "url": "https://www.y-mainichi.co.jp/news/40338/"
             }
         ],
-        "checked_on": "2026-01-01"
+        "checked_on": "2026-08-18"
     },
     {
         "name": "道の駅 本部町",


### PR DESCRIPTION
None of the 10 stations show a status or date change: 南種子町, 石垣市, 旭川市, 稚内空港, 長万部町, かかしの郷きょうわ and 上富良野町 all remain at the same "considering" stage they were at, with existing sources still live and no fresher announcement to report.

Add sources documenting active progress for three Hokkaido records: かもめ島 (Esashi) held a groundbreaking safety ceremony in May 2026, still targeting a June 2027 opening; the mayor of Niseko said in a June 2026 assembly session he wants to reconsider the on-site rebuild of ニセコビュープラザ, though nothing is decided yet; and 余市 (よいち) restarted market sounding in January 2026 after the original private redevelopment proposal fell through in January 2025, with the IC-area site itself unchanged.