### PR TITLE
Label plan sources with the titles of the pages they cite

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -9,7 +9,7 @@
         "lng": 142.3650083,
         "urls": [
             {
-                "title": "https://www.city.asahikawa.hokkaido.jp/10013/10014/d078561.html",
+                "title": "新たな「道の駅」の設置検討に向けたアンケート調査の集計結果について | 旭川市",
                 "url": "https://www.city.asahikawa.hokkaido.jp/10013/10014/d078561.html"
             }
         ],
@@ -29,7 +29,7 @@
                 "url": "https://www.town.shiranuka.lg.jp/section/gikai/h8v21a000000dlyc.html"
             },
             {
-                "title": "https://kushironews.jp/2023/06/15/433410/",
+                "title": "道の駅「恋問」本格着工へ ２５年４月オープン目指す【白糠】 – 釧路新聞電子版",
                 "url": "https://kushironews.jp/2023/06/15/433410/"
             }
         ],
@@ -45,7 +45,7 @@
         "lng": 141.7973887,
         "urls": [
             {
-                "title": "https://www.hokkaido-airports.co.jp/pdf/business_plan2020-2024.pdf",
+                "title": "中期事業計画（2020～2024年度）",
                 "url": "https://www.hokkaido-airports.co.jp/pdf/business_plan2020-2024.pdf"
             }
         ],
@@ -85,7 +85,7 @@
         "lng": 140.380348,
         "urls": [
             {
-                "title": "https://www.town.oshamambe.lg.jp/uploaded/attachment/5029.pdf",
+                "title": "第4次長万部町まちづくり総合計画 2021-2030",
                 "url": "https://www.town.oshamambe.lg.jp/uploaded/attachment/5029.pdf"
             }
         ],
@@ -101,7 +101,7 @@
         "lng": 140.1189399,
         "urls": [
             {
-                "title": "https://www.hokkaido-esashi.jp/modules/chousei/content0428.html",
+                "title": "「北の江の島」拠点施設整備基本計画を策定しました",
                 "url": "https://www.hokkaido-esashi.jp/modules/chousei/content0428.html"
             },
             {
@@ -113,11 +113,11 @@
                 "url": "https://mykoho.jp/article/%E5%8C%97%E6%B5%B7%E9%81%93%E6%B1%9F%E5%B7%AE%E7%94%BA/%E5%BA%83%E5%A0%B1%E3%81%88%E3%81%95%E3%81%97-%E4%BB%A4%E5%92%8C6%E5%B9%B412%E6%9C%88%E5%8F%B7/%E6%96%B0%E3%81%9F%E3%81%AA%E3%80%8C%E9%81%93%E3%81%AE%E9%A7%85%E3%80%8D%E3%82%92%E7%9B%AE%E6%8C%87%E3%81%97%E3%81%A6%E6%B5%B7%E3%81%A8%E3%81%BE%E3%81%A1%E3%82%92%E3%81%A4%E3%81%AA%E3%81%90%E3%81%BE/"
             },
             {
-                "title": "https://www.hokkaido-esashi.jp/modules/chousei/content0535.html",
+                "title": "（仮称）道の駅かもめ島基本計画概要について",
                 "url": "https://www.hokkaido-esashi.jp/modules/chousei/content0535.html"
             },
             {
-                "title": "https://www.hokkaido-np.co.jp/article/1305345/",
+                "title": "江差・道の駅「かもめ島」整備費 町、負担4.8億円と住民説明：北海道新聞デジタル",
                 "url": "https://www.hokkaido-np.co.jp/article/1305345/"
             },
             {
@@ -141,7 +141,7 @@
                 "url": "https://e-kensin.net/news/156609.html"
             },
             {
-                "title": "https://www.town.niseko.lg.jp/information/3810/",
+                "title": "第207回まちづくり町民講座「道の駅ニセコビュープラザの再整備に向けて」の開催について | インフォメーション | 北海道ニセコ町",
                 "url": "https://www.town.niseko.lg.jp/information/3810/"
             },
             {
@@ -169,7 +169,7 @@
                 "url": "https://www.town.kyowa.hokkaido.jp/soshiki/sangyouka/news/files/michinoekiseibikeikaku.pdf"
             },
             {
-                "title": "https://kurashigoto.hokkaido.jp/report/20250124090000.php",
+                "title": "【共和町】町民と共に創る共和町の道の駅。官民連携の運営会社「とものば」 | 北海道の人、暮らし、仕事。 くらしごと",
                 "url": "https://kurashigoto.hokkaido.jp/report/20250124090000.php"
             },
             {
@@ -177,15 +177,15 @@
                 "url": "https://www.instagram.com/p/DBSLM4sT4NE/"
             },
             {
-                "title": "https://www.town.kyowa.hokkaido.jp/tourism/?content=1284",
+                "title": "令和9年度オープン予定 共和町道の駅（仮称）｜道の駅｜共和町",
                 "url": "https://www.town.kyowa.hokkaido.jp/tourism/?content=1284"
             },
             {
-                "title": "https://www.hokkaido-np.co.jp/article/1226421/",
+                "title": "27年度開業目指す道の駅、名称「かかしの郷」に 共和：北海道新聞デジタル",
                 "url": "https://www.hokkaido-np.co.jp/article/1226421/"
             },
             {
-                "title": "https://www.tomonoba.co.jp/kyowa_michinoeki/",
+                "title": "かかしの郷 きょうわ",
                 "url": "https://www.tomonoba.co.jp/kyowa_michinoeki/"
             }
         ],
@@ -201,7 +201,7 @@
         "lng": 140.6386001,
         "urls": [
             {
-                "title": "http://www.town.furubira.lg.jp/info/detail.php?id=351",
+                "title": "（仮称）道の駅ふるびら指定管理候補者 公募型プロポーザルの実施について｜建設・産業｜新着情報",
                 "url": "http://www.town.furubira.lg.jp/info/detail.php?id=351"
             },
             {
@@ -225,11 +225,11 @@
         "lng": 140.8177311,
         "urls": [
             {
-                "title": "https://www.town.yoichi.hokkaido.jp/sangyou/machidukuri/michinoeki_saihenseibi.html",
+                "title": "道の駅再編整備について｜産業・経済・まちづくり",
                 "url": "https://www.town.yoichi.hokkaido.jp/sangyou/machidukuri/michinoeki_saihenseibi.html"
             },
             {
-                "title": "https://www.town.yoichi.hokkaido.jp/kankou/spot/atarashii_michinoeki.html",
+                "title": "道の駅再編整備について｜観光・イベント情報",
                 "url": "https://www.town.yoichi.hokkaido.jp/kankou/spot/atarashii_michinoeki.html"
             },
             {
@@ -237,7 +237,7 @@
                 "url": "https://mykoho.jp/article/%E5%8C%97%E6%B5%B7%E9%81%93%E4%BD%99%E5%B8%82%E7%94%BA/%E5%BA%83%E5%A0%B1%E3%82%88%E3%81%84%E3%81%A1-%E4%BB%A4%E5%92%8C5%E5%B9%B410%E6%9C%88%E5%8F%B7/%E7%AC%AC1%E5%9B%9E-%E6%96%B0%E3%81%97%E3%81%84%E9%81%93%E3%81%AE%E9%A7%85%E3%81%A0%E3%82%88%E3%82%8A/"
             },
             {
-                "title": "https://e-kensin.net/n/n7c3f4686e956",
+                "title": "【余市】民間提案の道の駅再編整備が白紙に／建設の方針は変わらず｜e-kensinニュース 北海道建設新聞",
                 "url": "https://e-kensin.net/n/n7c3f4686e956"
             },
             {
@@ -257,7 +257,7 @@
         "lng": 142.4671275,
         "urls": [
             {
-                "title": "https://note.com/dokode/n/nd8c123190a27",
+                "title": "【中富良野・上富良野】２つの道の駅構想が浮上｜e-kensinニュース 北海道建設新聞",
                 "url": "https://note.com/dokode/n/nd8c123190a27"
             },
             {
@@ -277,7 +277,7 @@
         "lng": 142.425137,
         "urls": [
             {
-                "title": "https://note.com/dokode/n/nd8c123190a27",
+                "title": "【中富良野・上富良野】２つの道の駅構想が浮上｜e-kensinニュース 北海道建設新聞",
                 "url": "https://note.com/dokode/n/nd8c123190a27"
             }
         ],
@@ -313,7 +313,7 @@
         "lng": 141.3584216,
         "urls": [
             {
-                "title": "https://www.nikkei.com/article/DGXZQOFC1938K0Z11C22A0000000/",
+                "title": "「ウポポイ」周辺に道の駅整備へ 北海道白老町長 - 日本経済新聞",
                 "url": "https://www.nikkei.com/article/DGXZQOFC1938K0Z11C22A0000000/"
             }
         ],
@@ -345,15 +345,15 @@
         "lng": 142.7901803,
         "urls": [
             {
-                "title": "https://www.shintoku-town.jp/gyousei/koukai_kouhyou/tiikisenryaku/mitinoeki/",
+                "title": "道の駅整備 | 地域戦略室 | 情報の公開・公表（計画等） | 行政情報 | 北海道 新得町",
                 "url": "https://www.shintoku-town.jp/gyousei/koukai_kouhyou/tiikisenryaku/mitinoeki/"
             },
             {
-                "title": "https://www.hkd.mlit.go.jp/ob/release/inr9av0000004x02-att/inr9av0000007co3.pdf",
+                "title": "「新得スマートインターチェンジ（仮称）」連結許可書の伝達式を開催します",
                 "url": "https://www.hkd.mlit.go.jp/ob/release/inr9av0000004x02-att/inr9av0000007co3.pdf"
             },
             {
-                "title": "https://project.nikkeibp.co.jp/atclppp/PPP/news/121103630/",
+                "title": "道の駅をPA・スマートICと一体的にDBOで整備、新得町が事業者を再公募｜新・公民連携最前線｜PPPまちづくり",
                 "url": "https://project.nikkeibp.co.jp/atclppp/PPP/news/121103630/"
             },
             {
@@ -393,7 +393,7 @@
                 "url": "https://www.town.kosaka.akita.jp/machinososhiki/kensetsuka/kensetsuhan/2237.html"
             },
             {
-                "title": "https://www.town.kosaka.akita.jp/material/files/group/1/r201koho3.pdf",
+                "title": "広報小坂 P3 和井内エリア鳥瞰図",
                 "url": "https://www.town.kosaka.akita.jp/material/files/group/1/r201koho3.pdf"
             },
             {
@@ -421,7 +421,7 @@
         "lng": 141.2210196,
         "urls": [
             {
-                "title": "https://www.city.mutsu.lg.jp/kurashi/machi/toshikeikaku/files/20141031-185305.pdf",
+                "title": "（仮称）「道の駅」整備事業について",
                 "url": "https://www.city.mutsu.lg.jp/kurashi/machi/toshikeikaku/files/20141031-185305.pdf"
             },
             {
@@ -461,11 +461,11 @@
         "lng": 141.1728461,
         "urls": [
             {
-                "title": "https://www.city.morioka.iwate.jp/shisei/tamayama_office/oshirase/1042800/index.html",
+                "title": "道の駅もりおか渋民（愛称：たみっと） 令和7年4月オープン！",
                 "url": "https://www.city.morioka.iwate.jp/shisei/tamayama_office/oshirase/1042800/index.html"
             },
             {
-                "title": "https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/001/040/747/220901_12.pdf",
+                "title": "道の駅もりおか渋民 令和６年春開業予定！",
                 "url": "https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/001/040/747/220901_12.pdf"
             },
             {
@@ -473,7 +473,7 @@
                 "url": "https://www.iwate-np.co.jp/article/2023/9/23/150482"
             },
             {
-                "title": "https://newsdig.tbs.co.jp/articles/-/736641?display=1",
+                "title": "このままだと地盤沈下の恐れ 石川啄木ゆかりの地・盛岡市渋民に整備中の道の駅 追加工事で開業半年あまり延期し2025年春に 産直の品ぞろえも考慮 | TBS NEWS DIG (1ページ)",
                 "url": "https://newsdig.tbs.co.jp/articles/-/736641?display=1"
             }
         ],
@@ -513,7 +513,7 @@
                 "url": "https://www.city.ichinoseki.iwate.jp/index.cfm/6,158855,91,6,html"
             },
             {
-                "title": "https://smout.jp/plans/6947",
+                "title": "新しい道の駅を一緒に作ってくれる「地域おこし協力隊」を募集します！(岩手県一関市) | 地域とつながるプラットフォーム スマウト (SMOUT)",
                 "url": "https://smout.jp/plans/6947"
             },
             {
@@ -533,11 +533,11 @@
         "lng": 141.97318,
         "urls": [
             {
-                "title": "https://www.yamada-funakoshi.jp/facility/",
+                "title": "施設情報 - 道の駅ふなこし・いぐべす",
                 "url": "https://www.yamada-funakoshi.jp/facility/"
             },
             {
-                "title": "https://www.town.yamada.iwate.jp/docs/8945.html",
+                "title": "道の駅ふなこしリニューアルオープン記念式典について",
                 "url": "https://www.town.yamada.iwate.jp/docs/8945.html"
             }
         ],
@@ -557,7 +557,7 @@
                 "url": "https://www.town.yamada.iwate.jp/fs/4/9/0/5/5/_/gaiyou.pdf"
             },
             {
-                "title": "https://www.town.yamada.iwate.jp/docs/3550.html",
+                "title": "「（仮称）新・道の駅『やまだ』」指定管理候補者を募集します【10月19日更新】",
                 "url": "https://www.town.yamada.iwate.jp/docs/3550.html"
             },
             {
@@ -565,7 +565,7 @@
                 "url": "https://www.thr.mlit.go.jp/sanriku/06_office/gyoumugaiyou/R4/pdf/P11.pdf"
             },
             {
-                "title": "https://www.thr.mlit.go.jp/sanriku/10_iji/miyakowest/news/20220927.pdf",
+                "title": "新・道の駅やまだ 愛称「おいすた」に決定！",
                 "url": "https://www.thr.mlit.go.jp/sanriku/10_iji/miyakowest/news/20220927.pdf"
             }
         ],
@@ -601,7 +601,7 @@
         "lng": 141.3084772,
         "urls": [
             {
-                "title": "https://www.town.ichinohe.iwate.jp/soshikikarasagasu/shokokankoka/michinoeki/index.html",
+                "title": "道の駅事業推進室／一戸町",
                 "url": "https://www.town.ichinohe.iwate.jp/soshikikarasagasu/shokokankoka/michinoeki/index.html"
             },
             {
@@ -609,7 +609,7 @@
                 "url": "https://www.iwate-np.co.jp/article/2023/12/9/154913"
             },
             {
-                "title": "https://www.daily-tohoku.news/archives/201786",
+                "title": "一戸町の道の駅、建設候補地決定 当初予定の北側隣接地 – デーリー東北",
                 "url": "https://www.daily-tohoku.news/archives/201786"
             }
         ],
@@ -629,7 +629,7 @@
                 "url": "https://www.city.ishinomaki.lg.jp/cont/10240000/501/50001.pdf"
             },
             {
-                "title": "https://note.com/hibishinbun/n/nf161f99b9c34",
+                "title": "進む若者の地元離れ 河南・桃生地区 鍵握る就労と環境整備｜石巻Days（石巻日日新聞社公式）",
                 "url": "https://note.com/hibishinbun/n/nf161f99b9c34"
             }
         ],
@@ -645,27 +645,27 @@
         "lng": 140.613047,
         "urls": [
             {
-                "title": "https://www.city.shiroishi.miyagi.jp/soshiki/43/21812.html",
+                "title": "（仮称）道の駅しろいし基本計画を策定しました",
                 "url": "https://www.city.shiroishi.miyagi.jp/soshiki/43/21812.html"
             },
             {
-                "title": "https://www.city.shiroishi.miyagi.jp/soshiki/43/29239.html",
+                "title": "（仮称）道の駅しろいし整備事業に係るPFI事業者選定について",
                 "url": "https://www.city.shiroishi.miyagi.jp/soshiki/43/29239.html"
             },
             {
-                "title": "http://www.jcpress.co.jp/wp01/?p=28485",
+                "title": "日本建設新聞社 » SIC周辺整備に106億円 工業団地や道の駅など(宮城県 白石市)",
                 "url": "http://www.jcpress.co.jp/wp01/?p=28485"
             },
             {
-                "title": "https://newsdig.tbs.co.jp/articles/-/2258562",
+                "title": "仮称「道の駅しろいし」11月着工 2027年7月完成予定 防災拠点機能も 宮城・白石市 | TBS NEWS DIG",
                 "url": "https://newsdig.tbs.co.jp/articles/-/2258562"
             },
             {
-                "title": "https://www.city.shiroishi.miyagi.jp/soshiki/43/37693.html",
+                "title": "(仮称)道の駅しろいし整備事業 事業概要について",
                 "url": "https://www.city.shiroishi.miyagi.jp/soshiki/43/37693.html"
             },
             {
-                "title": "https://kahoku.news/articles/20251029khn000042.html",
+                "title": "「道の駅しろいし」予定地で起工式 隣接する東北道スマートICも 宮城・白石 | 河北新報オンライン",
                 "url": "https://kahoku.news/articles/20251029khn000042.html"
             }
         ],
@@ -685,7 +685,7 @@
                 "url": "https://www.kuriharacity.jp/li/030/140/060/010/PAGE000000000000007006.html"
             },
             {
-                "title": "https://www.kuriharacity.jp/w023/PAGE000000000000008654.html",
+                "title": "栗原市道の駅基本構想策定業務｜宮城県栗原市",
                 "url": "https://www.kuriharacity.jp/w023/PAGE000000000000008654.html"
             }
         ],
@@ -705,7 +705,7 @@
                 "url": "https://www.city.higashimatsushima.miyagi.jp/index.cfm/22,33475,71,html"
             },
             {
-                "title": "https://kahoku.news/articles/20240120khn000011.html",
+                "title": "道の駅11月開業へ着工 矢本ＰＡ接続、年100万人利用想定 東松島市 | 河北新報オンライン",
                 "url": "https://kahoku.news/articles/20240120khn000011.html"
             }
         ],
@@ -721,7 +721,7 @@
         "lng": 140.8952018,
         "urls": [
             {
-                "title": "https://www.tomiya-city.miyagi.jp/uploads/pdf/327731df21ce3260071f5699fbbd2774a8d1b0c5.pdf",
+                "title": "富谷市総合計画 基本構想・前期基本計画",
                 "url": "https://www.tomiya-city.miyagi.jp/uploads/pdf/327731df21ce3260071f5699fbbd2774a8d1b0c5.pdf"
             }
         ],
@@ -737,11 +737,11 @@
         "lng": 140.3115286,
         "urls": [
             {
-                "title": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/seisaku/1009687/index.html",
+                "title": "道の駅整備事業",
                 "url": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/seisaku/1009687/index.html"
             },
             {
-                "title": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/keikaku/1008370/1002617.html",
+                "title": "山形市道の駅整備構想を策定しました",
                 "url": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/keikaku/1008370/1002617.html"
             },
             {
@@ -761,11 +761,11 @@
         "lng": 140.6587766,
         "urls": [
             {
-                "title": "https://www.town.zao.miyagi.jp/reiki_int/reiki_honbun/i800RG00000907.html",
+                "title": "蔵王町道の駅設置検討委員会設置要綱",
                 "url": "https://www.town.zao.miyagi.jp/reiki_int/reiki_honbun/i800RG00000907.html"
             },
             {
-                "title": "http://www.jcpress.co.jp/wp01/?p=25775",
+                "title": "日本建設新聞社 » 道の駅設置を検討調査 業務委託のプロポ開始 21年度末に可能性判断(蔵王町)",
                 "url": "http://www.jcpress.co.jp/wp01/?p=25775"
             }
         ],
@@ -781,11 +781,11 @@
         "lng": 140.6733673,
         "urls": [
             {
-                "title": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001372403.pdf",
+                "title": "「川崎町道の駅」基本構想",
                 "url": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001372403.pdf"
             },
             {
-                "title": "https://www.town.kawasaki.miyagi.jp/soshiki/chishin/1882.html",
+                "title": "道の駅の方針について",
                 "url": "https://www.town.kawasaki.miyagi.jp/soshiki/chishin/1882.html"
             }
         ],
@@ -801,11 +801,11 @@
         "lng": 141.0429077,
         "urls": [
             {
-                "title": "https://www.town.rifu.miyagi.jp/material/files/group/11/5cc16322005.pdf",
+                "title": "（仮称）浜田復興交流センター 事業概要書（案）",
                 "url": "https://www.town.rifu.miyagi.jp/material/files/group/11/5cc16322005.pdf"
             },
             {
-                "title": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001372406.pdf",
+                "title": "（仮称）浜田地区道の駅 サウンディング調査資料",
                 "url": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001372406.pdf"
             }
         ],
@@ -821,11 +821,11 @@
         "lng": 139.9868795,
         "urls": [
             {
-                "title": "https://www.town.happo.lg.jp/uploads/public/archive_0000002072_00/%E5%BE%A1%E6%89%80%E3%81%AE%E5%8F%B0%E3%82%A8%E3%83%AA%E3%82%A2%E5%86%8D%E6%A7%8B%E7%AF%89%E6%A7%8B%E6%83%B3.pdf",
+                "title": "御所の台エリア再構築構想",
                 "url": "https://www.town.happo.lg.jp/uploads/public/archive_0000002072_00/%E5%BE%A1%E6%89%80%E3%81%AE%E5%8F%B0%E3%82%A8%E3%83%AA%E3%82%A2%E5%86%8D%E6%A7%8B%E7%AF%89%E6%A7%8B%E6%83%B3.pdf"
             },
             {
-                "title": "https://www.town.happo.lg.jp/archive/contents-1375",
+                "title": "【令和５年１月９日締切】道の駅「はちもり」移転・御所の台エリア再構築に係るアンケート調査のお願い | 八峰町",
                 "url": "https://www.town.happo.lg.jp/archive/contents-1375"
             },
             {
@@ -845,7 +845,7 @@
         "lng": 140.2983308,
         "urls": [
             {
-                "title": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/keikaku/1008370/1002617.html",
+                "title": "山形市道の駅整備構想を策定しました",
                 "url": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/keikaku/1008370/1002617.html"
             }
         ],
@@ -861,15 +861,15 @@
         "lng": 139.5519652,
         "urls": [
             {
-                "title": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/20220413.files/gaiyou.pdf",
+                "title": "温海地域における道の駅移転整備に係る基盤整備検討調査業務 報告書（概要版）",
                 "url": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/20220413.files/gaiyou.pdf"
             },
             {
-                "title": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/michieki_enki.html",
+                "title": "道の駅あつみ移転整備事業の開業時期の延期について 鶴岡市",
                 "url": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/michieki_enki.html"
             },
             {
-                "title": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/logomark.html",
+                "title": "道の駅あつみ「うぇるかぶ」のロゴマークが決定しました 鶴岡市",
                 "url": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/logomark.html"
             }
         ],
@@ -885,11 +885,11 @@
         "lng": 140.2949716,
         "urls": [
             {
-                "title": "https://www.city.shinjo.yamagata.jp/s012/160/20230324172550.html",
+                "title": "令和4年度 第2回 新庄インターチェンジ付近道の駅検討会を開催しました - 新庄市",
                 "url": "https://www.city.shinjo.yamagata.jp/s012/160/20230324172550.html"
             },
             {
-                "title": "https://www.fnn.jp/articles/-/585373",
+                "title": "市長選の争点・新庄IC付近の“道の駅”に「温泉施設」整備目指す…初当選の山科朝則氏がビジョンを語る【山形発】｜FNNプライムオンライン",
                 "url": "https://www.fnn.jp/articles/-/585373"
             },
             {
@@ -909,7 +909,7 @@
         "lng": 140.3819252,
         "urls": [
             {
-                "title": "https://www.city.murayama.lg.jp/shisei/keikaku_seisaku/sinmitinoekiseibizig/index.html",
+                "title": "新「道の駅」整備事業 村山市",
                 "url": "https://www.city.murayama.lg.jp/shisei/keikaku_seisaku/sinmitinoekiseibizig/index.html"
             },
             {
@@ -929,11 +929,11 @@
         "lng": 140.4095716,
         "urls": [
             {
-                "title": "https://www.city.higashine.yamagata.jp/section_list/section014/roadside/2024",
+                "title": "東根市「道の駅」整備基本計画 | 東根市 「ようこそ果樹王国ひがしねへ」",
                 "url": "https://www.city.higashine.yamagata.jp/section_list/section014/roadside/2024"
             },
             {
-                "title": "https://kahoku.news/articles/20230517khn000071.html",
+                "title": "道の駅、狙うは仙台圏 山形・東根市、29年度開業目指す | 河北新報オンライン",
                 "url": "https://kahoku.news/articles/20230517khn000071.html"
             }
         ],
@@ -953,11 +953,11 @@
                 "url": "https://mogami.tv/admin/admin-info/siryou-etsuran/data/20200623145806-kouryu.pdf"
             },
             {
-                "title": "https://www.furusato-tax.jp/enterprise/258",
+                "title": "道の駅『もがみ（仮称）』整備事業 | 企業版ふるさと納税のポータルサイトは企業版ふるさとチョイス",
                 "url": "https://www.furusato-tax.jp/enterprise/258"
             },
             {
-                "title": "https://shinjo-mogami.mypl.net/shop/00000371404/news?d=2547835",
+                "title": "「道の駅もがみ(仮称)」本格的な工事がスタート! | 川の駅 ヤナ茶屋もがみのニュース | まいぷれ[新庄・最上]",
                 "url": "https://shinjo-mogami.mypl.net/shop/00000371404/news?d=2547835"
             },
             {
@@ -977,15 +977,15 @@
         "lng": 140.3105427,
         "urls": [
             {
-                "title": "https://www.city.shinjo.yamagata.jp/s012/160/20220530131719.html",
+                "title": "エコロジーガーデン周辺「道の駅」整備計画の策定について - 新庄市",
                 "url": "https://www.city.shinjo.yamagata.jp/s012/160/20220530131719.html"
             },
             {
-                "title": "https://www.city.shinjo.yamagata.jp/s012/050/030/20230331140116.html",
+                "title": "都市再生整備計画を推進しております。 - 新庄市",
                 "url": "https://www.city.shinjo.yamagata.jp/s012/050/030/20230331140116.html"
             },
             {
-                "title": "https://koubo.jp/contest/250218",
+                "title": "道の駅「新庄エコロジーガーデン原蚕の杜」ロゴマーク募集 | 公募/コンテスト/コンペ情報なら「Koubo」",
                 "url": "https://koubo.jp/contest/250218"
             },
             {
@@ -1005,19 +1005,19 @@
         "lng": 139.8925855,
         "urls": [
             {
-                "title": "https://www.town.yuza.yamagata.jp/ou/kikaku/pat/pd1215120149.html",
+                "title": "遊佐パーキングエリアタウン（新道の駅）整備計画について",
                 "url": "https://www.town.yuza.yamagata.jp/ou/kikaku/pat/pd1215120149.html"
             },
             {
-                "title": "https://www.town.yuza.yamagata.jp/archive/p20251104113155",
+                "title": "新・道の駅の愛称が決定しました！",
                 "url": "https://www.town.yuza.yamagata.jp/archive/p20251104113155"
             },
             {
-                "title": "https://www.town.yuza.yamagata.jp/archive/p20260709105255",
+                "title": "遊佐パーキングエリアタウン事業 新道の駅鳥海 本体工事起工式を行いました",
                 "url": "https://www.town.yuza.yamagata.jp/archive/p20260709105255"
             },
             {
-                "title": "https://www.yuza-eppeke.com/",
+                "title": "道の駅 遊佐 えっぺけ 鳥海",
                 "url": "https://www.yuza-eppeke.com/"
             }
         ],
@@ -1037,7 +1037,7 @@
                 "url": "https://www3.nhk.or.jp/lnews/fukushima/20250131/6050028627.html"
             },
             {
-                "title": "https://iwaki-minpo.co.jp/news/2025/01/302525/",
+                "title": "小名浜「ら・ら・ミュウ」道の駅に登録 ９月にオープンへ いわき代表する拠点に | 株式会社いわき民報社",
                 "url": "https://iwaki-minpo.co.jp/news/2025/01/302525/"
             }
         ],
@@ -1073,7 +1073,7 @@
         "lng": 140.5764032,
         "urls": [
             {
-                "title": "https://www.city.tamura.lg.jp/soshiki/1/assets/%E3%80%90%E3%83%91%E3%83%96%E3%83%AA%E3%83%83%E3%82%AF%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E6%84%8F%E8%A6%8B%E5%8F%8D%E6%98%A0%E3%80%91%E7%AC%AC%EF%BC%92%E6%AC%A1%E7%94%B0%E6%9D%91%E5%B8%82%E7%B7%8F%E5%90%88%E8%A8%88%E7%94%BB%E6%A1%88.pdf",
+                "title": "第２次田村市総合計画（パブリックコメント意見反映案）",
                 "url": "https://www.city.tamura.lg.jp/soshiki/1/assets/%E3%80%90%E3%83%91%E3%83%96%E3%83%AA%E3%83%83%E3%82%AF%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E6%84%8F%E8%A6%8B%E5%8F%8D%E6%98%A0%E3%80%91%E7%AC%AC%EF%BC%92%E6%AC%A1%E7%94%B0%E6%9D%91%E5%B8%82%E7%B7%8F%E5%90%88%E8%A8%88%E7%94%BB%E6%A1%88.pdf"
             }
         ],
@@ -1089,7 +1089,7 @@
         "lng": 140.3957157,
         "urls": [
             {
-                "title": "https://ameblo.jp/ugg38037/entry-12790611091.html",
+                "title": "「あだたらの里直売所」道の駅化へ | 花かつみ",
                 "url": "https://ameblo.jp/ugg38037/entry-12790611091.html"
             }
         ],
@@ -1105,7 +1105,7 @@
         "lng": 139.3149395,
         "urls": [
             {
-                "title": "https://www.town.tadami.lg.jp/referenceroom/station.html",
+                "title": "道の駅【町政資料室】｜只見町公式ホームページ｜福島県",
                 "url": "https://www.town.tadami.lg.jp/referenceroom/station.html"
             }
         ],
@@ -1121,7 +1121,7 @@
         "lng": 140.153976,
         "urls": [
             {
-                "title": "https://www.vill.nishigo.fukushima.jp/sonseijoho/kyotenseibi/michinoekinishigoseibinikansurukoto/2352.html",
+                "title": "（仮称）道の駅「にしごう」基本計画／西郷村",
                 "url": "https://www.vill.nishigo.fukushima.jp/sonseijoho/kyotenseibi/michinoekinishigoseibinikansurukoto/2352.html"
             }
         ],
@@ -1157,7 +1157,7 @@
         "lng": 140.4247731,
         "urls": [
             {
-                "title": "https://www.town.yamatsuri.fukushima.jp/data/doc/1617263274_doc_10_0.pdf",
+                "title": "第６次矢祭町総合計画 2021～2026",
                 "url": "https://www.town.yamatsuri.fukushima.jp/data/doc/1617263274_doc_10_0.pdf"
             }
         ],
@@ -1173,7 +1173,7 @@
         "lng": 140.5097361,
         "urls": [
             {
-                "title": "https://www.vill.samegawa.fukushima.jp/sp/page/page001953.html",
+                "title": "鮫川村中心地域活性化協議会",
                 "url": "https://www.vill.samegawa.fukushima.jp/sp/page/page001953.html"
             }
         ],
@@ -1189,15 +1189,15 @@
         "lng": 140.4292731,
         "urls": [
             {
-                "title": "https://www.town.ishikawa.fukushima.jp/admin/industry/03/02.html",
+                "title": "道の駅整備事業基本構想及び基本計画｜石川町",
                 "url": "https://www.town.ishikawa.fukushima.jp/admin/industry/03/02.html"
             },
             {
-                "title": "https://newsdig.tbs.co.jp/articles/-/708608?display=1",
+                "title": "事業費の上限、事前に決定 全国的にもめずらしい手法で「道の駅」建設へ 福島 | TBS NEWS DIG (1ページ)",
                 "url": "https://newsdig.tbs.co.jp/articles/-/708608?display=1"
             },
             {
-                "title": "https://www.town.ishikawa.fukushima.jp/admin/b011787c79a94fe9f06df3826a8d4b17.pdf",
+                "title": "株式会社ＴＴＣグループと道の駅整備事業基本協定を締結！",
                 "url": "https://www.town.ishikawa.fukushima.jp/admin/b011787c79a94fe9f06df3826a8d4b17.pdf"
             },
             {
@@ -1209,7 +1209,7 @@
                 "url": "https://www.minpo.jp/news/moredetail/20250502124062"
             },
             {
-                "title": "https://www.town.ishikawa.fukushima.jp/kairan/files/68b6e4b1fe469f1f58abefa2c6379a42_3.pdf",
+                "title": "道の駅令和８年７月オープン予定（石川町道の駅準備室）",
                 "url": "https://www.town.ishikawa.fukushima.jp/kairan/files/68b6e4b1fe469f1f58abefa2c6379a42_3.pdf"
             },
             {
@@ -1217,11 +1217,11 @@
                 "url": "https://news.yahoo.co.jp/articles/57013c298ab3c1fda432fcc7fe904363b514b7f0"
             },
             {
-                "title": "https://www.town.ishikawa.fukushima.jp/admin/ishikawa/info/010535.html",
+                "title": "道の駅石川のオープンについて｜石川町",
                 "url": "https://www.town.ishikawa.fukushima.jp/admin/ishikawa/info/010535.html"
             },
             {
-                "title": "https://www.minyu-net.com/news/detail/2026072208035152618",
+                "title": "道の駅石川、9月18日に開業 福島県内37カ所目:地域ニュース:福島民友新聞社",
                 "url": "https://www.minyu-net.com/news/detail/2026072208035152618"
             }
         ],
@@ -1237,7 +1237,7 @@
         "lng": 140.5581662,
         "urls": [
             {
-                "title": "https://www.vill.hirata.fukushima.jp/soshiki/15/3806.html",
+                "title": "道の駅ひらた移転再整備事業",
                 "url": "https://www.vill.hirata.fukushima.jp/soshiki/15/3806.html"
             }
         ],
@@ -1253,15 +1253,15 @@
         "lng": 141.000591,
         "urls": [
             {
-                "title": "https://www.47news.jp/5094019.html",
+                "title": "「道の駅ひろの」規模縮小...面積半減 予定地に想定外巨大岩盤|47NEWS（よんななニュース）",
                 "url": "https://www.47news.jp/5094019.html"
             },
             {
-                "title": "https://hamasakoi.jp/archives/news1/0803-3/",
+                "title": "道の駅ひろの規模縮小 物産交流館など断念 | 浜さ恋",
                 "url": "https://hamasakoi.jp/archives/news1/0803-3/"
             },
             {
-                "title": "https://www.town.hirono.fukushima.jp/_res/projects/default_project/_page_/001/004/693/hirono.bousai.pdf",
+                "title": "「広野町防災の駅」整備事業 事業の概要・経緯",
                 "url": "https://www.town.hirono.fukushima.jp/_res/projects/default_project/_page_/001/004/693/hirono.bousai.pdf"
             }
         ],
@@ -1277,7 +1277,7 @@
         "lng": 140.9630577,
         "urls": [
             {
-                "title": "https://www.town.okuma.fukushima.jp/soshiki/fukkoujigyo/24531.html",
+                "title": "大熊IC周辺整備基本計画策定業務委託公募型プロポーザルの実施について - 大熊町ホームページ（復興事業課）",
                 "url": "https://www.town.okuma.fukushima.jp/soshiki/fukkoujigyo/24531.html"
             },
             {
@@ -1309,7 +1309,7 @@
         "lng": 140.7643658,
         "urls": [
             {
-                "title": "https://www.katsurao.org/uploaded/attachment/1019.pdf",
+                "title": "葛尾村中心拠点等整備計画 第４回検討委員会 議事次第",
                 "url": "https://www.katsurao.org/uploaded/attachment/1019.pdf"
             }
         ],
@@ -1325,11 +1325,11 @@
         "lng": 140.1362198,
         "urls": [
             {
-                "title": "https://www.city.ryugasaki.ibaraki.jp/kanko/michinoekiushikunuma/michinoeki/index.html",
+                "title": "道の駅整備事業の中止",
                 "url": "https://www.city.ryugasaki.ibaraki.jp/kanko/michinoekiushikunuma/michinoeki/index.html"
             },
             {
-                "title": "https://www.city.ryugasaki.ibaraki.jp/kanko/michinoekiushikunuma/michinoeki/michinoeki_houkousei.html",
+                "title": "龍ケ崎市道の駅整備事業の「中止」のお知らせ",
                 "url": "https://www.city.ryugasaki.ibaraki.jp/kanko/michinoekiushikunuma/michinoeki/michinoeki_houkousei.html"
             }
         ],
@@ -1345,7 +1345,7 @@
         "lng": 140.0764454,
         "urls": [
             {
-                "title": "https://newstsukuba.jp/54753/09/12/",
+                "title": "道の駅 市内2カ所に整備も検討 つくば市",
                 "url": "https://newstsukuba.jp/54753/09/12/"
             },
             {
@@ -1369,7 +1369,7 @@
         "lng": 140.5347934,
         "urls": [
             {
-                "title": "https://www.city.hitachinaka.lg.jp/_res/projects/default_project/_page_/001/002/725/78520896.pdf",
+                "title": "ひたちなか市第2期観光振興計画 第Ⅳ章 重点プロジェクト",
                 "url": "https://www.city.hitachinaka.lg.jp/_res/projects/default_project/_page_/001/002/725/78520896.pdf"
             }
         ],
@@ -1405,11 +1405,11 @@
         "lng": 139.9038923,
         "urls": [
             {
-                "title": "https://www.city.bando.lg.jp/data/doc/1601271051_doc_30_0.pdf",
+                "title": "坂東市地域利便施設 基本計画",
                 "url": "https://www.city.bando.lg.jp/data/doc/1601271051_doc_30_0.pdf"
             },
             {
-                "title": "https://www.city.bando.lg.jp/page/page009682.html",
+                "title": "茨城県初、圏央道初の「坂東ＰＡハイウェイ・オアシス」の事業を推進！",
                 "url": "https://www.city.bando.lg.jp/page/page009682.html"
             },
             {
@@ -1433,7 +1433,7 @@
         "lng": 140.5042214,
         "urls": [
             {
-                "title": "https://www.city.namegata.ibaraki.jp/machi/machi-shisetsu/machi-chiikishinkou/page013157.html",
+                "title": "「行方市地域振興施設（道の駅）」整備事業",
                 "url": "https://www.city.namegata.ibaraki.jp/machi/machi-shisetsu/machi-chiikishinkou/page013157.html"
             },
             {
@@ -1493,7 +1493,7 @@
         "lng": 139.508634,
         "urls": [
             {
-                "title": "https://www.city.ashikaga.tochigi.jp/urban/000065/000351/index.html",
+                "title": "道の駅",
                 "url": "https://www.city.ashikaga.tochigi.jp/urban/000065/000351/index.html"
             }
         ],
@@ -1509,7 +1509,7 @@
         "lng": 139.7771461,
         "urls": [
             {
-                "title": "https://www.city.kanuma.tochigi.jp/0283/info-0000011211-0.html",
+                "title": "花木センター再整備事業",
                 "url": "https://www.city.kanuma.tochigi.jp/0283/info-0000011211-0.html"
             }
         ],
@@ -1525,11 +1525,11 @@
         "lng": 139.9079805,
         "urls": [
             {
-                "title": "https://www.shimotsuke.co.jp/articles/-/779697",
+                "title": "上三川北部に新たな産業団地 町内初の道の駅も 町議会議員全員協議会｜県内主要,政治行政,地域の話題,経済｜下野新聞デジタルニュース｜下野新聞デジタル",
                 "url": "https://www.shimotsuke.co.jp/articles/-/779697"
             },
             {
-                "title": "https://trafficnews.jp/post/660292",
+                "title": "新4号国道の新たな「道の駅」整備事業が開始！ 高速IC／自動車工場／超巨大商業施設エリアのど真ん中!? | 乗りものニュース",
                 "url": "https://trafficnews.jp/post/660292"
             },
             {
@@ -1553,7 +1553,7 @@
         "lng": 139.000443,
         "urls": [
             {
-                "title": "https://www.city.shibukawa.lg.jp/manage/contents/upload/5f6d36bfe1d63.pdf",
+                "title": "第２次渋川市観光基本計画",
                 "url": "https://www.city.shibukawa.lg.jp/manage/contents/upload/5f6d36bfe1d63.pdf"
             }
         ],
@@ -1573,19 +1573,19 @@
                 "url": "https://www.city.annaka.lg.jp/page/2027.html"
             },
             {
-                "title": "https://www.jomo-news.co.jp/articles/-/371380",
+                "title": "「可能な限り早期のオープンを」横川駅周辺での「道の駅」新設で第１回検討委 群馬・安中市 | 上毛新聞電子版｜群馬県のニュース・スポーツ情報",
                 "url": "https://www.jomo-news.co.jp/articles/-/371380"
             },
             {
-                "title": "https://www.jomo-news.co.jp/articles/-/564548",
+                "title": "「オンリーワンの道の駅」へ 「道の駅」を鉄道文化むらと一体型施設に整備 群馬・安中市 | 上毛新聞電子版｜群馬県のニュース・スポーツ情報",
                 "url": "https://www.jomo-news.co.jp/articles/-/564548"
             },
             {
-                "title": "https://www.city.annaka.lg.jp/page/26310.html",
+                "title": "安中市道の駅の事業手法について",
                 "url": "https://www.city.annaka.lg.jp/page/26310.html"
             },
             {
-                "title": "https://www.city.annaka.lg.jp/page/20103.html",
+                "title": "安中市道の駅基本計画を策定しました",
                 "url": "https://www.city.annaka.lg.jp/page/20103.html"
             }
         ],
@@ -1601,11 +1601,11 @@
         "lng": 139.6710459,
         "urls": [
             {
-                "title": "https://www.city.saitama.jp/005/002/008/001/index.html",
+                "title": "さいたま市／地域経済活性化拠点（道の駅）の整備",
                 "url": "https://www.city.saitama.jp/005/002/008/001/index.html"
             },
             {
-                "title": "https://k-saito.jp/archives/1194",
+                "title": "さいたま市初の道の駅について | さいたま市議会議員 さいとう健一",
                 "url": "https://k-saito.jp/archives/1194"
             },
             {
@@ -1629,11 +1629,11 @@
         "lng": 139.4215801,
         "urls": [
             {
-                "title": "https://www.city.kumagaya.lg.jp/about/soshiki/sangyo/mitinoekiseibi/oshirase/index.html",
+                "title": "道の駅くるん熊谷に関するお知らせ：熊谷市ホームページ",
                 "url": "https://www.city.kumagaya.lg.jp/about/soshiki/sangyo/mitinoekiseibi/oshirase/index.html"
             },
             {
-                "title": "https://www.city.kumagaya.lg.jp/about/soshiki/sangyo/mitinoekiseibi/oshirase/meisyouketteikurun.html",
+                "title": "道の駅の名称が決定しました！：熊谷市ホームページ",
                 "url": "https://www.city.kumagaya.lg.jp/about/soshiki/sangyo/mitinoekiseibi/oshirase/meisyouketteikurun.html"
             }
         ],
@@ -1653,7 +1653,7 @@
                 "url": "https://www.city.gyoda.lg.jp/soshiki/toshiseibibu/kigyoyuchi/gyomu/michinoeki/1954.html"
             },
             {
-                "title": "https://www.ktr.mlit.go.jp/ktr_content/content/000739523.pdf",
+                "title": "道の駅「（仮称）ぎょうだ」（埼玉県行田市）",
                 "url": "https://www.ktr.mlit.go.jp/ktr_content/content/000739523.pdf"
             }
         ],
@@ -1669,7 +1669,7 @@
         "lng": 139.3286081,
         "urls": [
             {
-                "title": "https://www.city.hanno.lg.jp/material/files/group/2/betusidaigojihannoshisougoushinnkoukeikaku.pdf",
+                "title": "別紙 第5次飯能市総合振興計画実施計画 令和５年度重点施策",
                 "url": "https://www.city.hanno.lg.jp/material/files/group/2/betusidaigojihannoshisougoushinnkoukeikaku.pdf"
             }
         ],
@@ -1685,11 +1685,11 @@
         "lng": 139.4866894,
         "urls": [
             {
-                "title": "https://www.city.kounosu.saitama.jp/soshiki/49/",
+                "title": "道の駅整備プロジェクト",
                 "url": "https://www.city.kounosu.saitama.jp/soshiki/49/"
             },
             {
-                "title": "https://www.farmersforest.co.jp/info/282",
+                "title": "INFORMATION | FARMERS FOREST GROUP",
                 "url": "https://www.farmersforest.co.jp/info/282"
             }
         ],
@@ -1705,7 +1705,7 @@
         "lng": 139.8255214,
         "urls": [
             {
-                "title": "https://www.city.koshigaya.saitama.jp/kurashi_shisei/shisei/keikaku/oshirase/michinoeki_questionnaire.html",
+                "title": "（仮称）越谷市「道の駅」整備事業に関するアンケートを実施します 越谷市公式ホームページ",
                 "url": "https://www.city.koshigaya.saitama.jp/kurashi_shisei/shisei/keikaku/oshirase/michinoeki_questionnaire.html"
             },
             {
@@ -1725,15 +1725,15 @@
         "lng": 139.584067,
         "urls": [
             {
-                "title": "https://www.city.kuki.lg.jp/machizukuri/nogyo/michinoeki/1008066.html",
+                "title": "農業振興拠点（道の駅）基本構想を策定しました（令和5年8月）",
                 "url": "https://www.city.kuki.lg.jp/machizukuri/nogyo/michinoeki/1008066.html"
             },
             {
-                "title": "https://www.saitama-np.co.jp/articles/42638/postDetail",
+                "title": "直売所もスポーツも楽しめる施設に…久喜に「道の駅」誕生へ JA南彩と提携、菖蒲エリアに2027年開業目標｜埼玉新聞｜埼玉の最新ニュース・スポーツ・地域の話題",
                 "url": "https://www.saitama-np.co.jp/articles/42638/postDetail"
             },
             {
-                "title": "https://www.city.kuki.lg.jp/machizukuri/nogyo/michinoeki/1012668.html",
+                "title": "農業振興拠点（道の駅）管理運営計画を策定しました（令和8年3月）",
                 "url": "https://www.city.kuki.lg.jp/machizukuri/nogyo/michinoeki/1012668.html"
             }
         ],
@@ -1769,7 +1769,7 @@
         "lng": 139.6621755,
         "urls": [
             {
-                "title": "http://www.city.hasuda.saitama.jp/toshike/machi/toshi/toshikekaku/documents/toshimasuzentai.pdf",
+                "title": "蓮田市都市計画マスタープラン",
                 "url": "http://www.city.hasuda.saitama.jp/toshike/machi/toshi/toshikekaku/documents/toshimasuzentai.pdf"
             }
         ],
@@ -1785,7 +1785,7 @@
         "lng": 139.8555545,
         "urls": [
             {
-                "title": "https://www.city.yoshikawa.saitama.jp/index.cfm/23,93176,c,html/93176/20220327-082937.pdf",
+                "title": "吉川市農業パーク基本構想",
                 "url": "https://www.city.yoshikawa.saitama.jp/index.cfm/23,93176,c,html/93176/20220327-082937.pdf"
             }
         ],
@@ -1801,7 +1801,7 @@
         "lng": 139.501032,
         "urls": [
             {
-                "title": "https://www.town.saitama-miyoshi.lg.jp/town/keikaku/documents/00_dai5ji_digest.pdf",
+                "title": "三芳町第５次総合計画 ダイジェスト版",
                 "url": "https://www.town.saitama-miyoshi.lg.jp/town/keikaku/documents/00_dai5ji_digest.pdf"
             },
             {
@@ -1849,11 +1849,11 @@
         "lng": 139.5229088,
         "urls": [
             {
-                "title": "https://www.city.okegawa.lg.jp/soshiki/shiminseikatsu/michinoeki/machidukuri/michinoeki/2264.html",
+                "title": "道の駅「べに花の郷おけがわ」整備事業について／桶川市",
                 "url": "https://www.city.okegawa.lg.jp/soshiki/shiminseikatsu/michinoeki/machidukuri/michinoeki/2264.html"
             },
             {
-                "title": "https://www.tokyo-np.co.jp/article/360580",
+                "title": "埼玉県内21カ所目 桶川の道の駅 「べに花の郷おけがわ」を登録 来年3月27日オープン予定：東京新聞デジタル",
                 "url": "https://www.tokyo-np.co.jp/article/360580"
             }
         ],
@@ -1869,7 +1869,7 @@
         "lng": 139.8354706,
         "urls": [
             {
-                "title": "http://www.town.matsubushi.lg.jp/www/contents/1607582275848/index.html",
+                "title": "松伏町道の駅整備計画について | 松伏町役場",
                 "url": "http://www.town.matsubushi.lg.jp/www/contents/1607582275848/index.html"
             }
         ],
@@ -1885,15 +1885,15 @@
         "lng": 139.9062058,
         "urls": [
             {
-                "title": "https://www.city.tateyama.chiba.jp/nousuisan/page100434.html",
+                "title": "「食のまちづくり拠点施設」整備事業 実施方針の公表 | 館山市役所",
                 "url": "https://www.city.tateyama.chiba.jp/nousuisan/page100434.html"
             },
             {
-                "title": "https://www.city.tateyama.chiba.jp/shokumachi/page000001_00021.html",
+                "title": "館山市の新しい道の駅の名称が決まりました！（令和6年2月オープン予定） | 館山市役所",
                 "url": "https://www.city.tateyama.chiba.jp/shokumachi/page000001_00021.html"
             },
             {
-                "title": "https://www.city.tateyama.chiba.jp/shokumachi/page000001_00028.html",
+                "title": "道の駅登録証伝達式が開催されました！ | 館山市役所",
                 "url": "https://www.city.tateyama.chiba.jp/shokumachi/page000001_00028.html"
             }
         ],
@@ -1913,7 +1913,7 @@
                 "url": "https://www.city.noda.chiba.jp/shisei/shingikai/1008854/1024943.html"
             },
             {
-                "title": "https://www.city.noda.chiba.jp/_res/projects/default_project/_page_/001/007/641/nodashisougoukeikaku230327.pdf",
+                "title": "野田市総合計画（後期基本計画）",
                 "url": "https://www.city.noda.chiba.jp/_res/projects/default_project/_page_/001/007/641/nodashisougoukeikaku230327.pdf"
             }
         ],
@@ -1929,7 +1929,7 @@
         "lng": 140.2881398,
         "urls": [
             {
-                "title": "https://www.nikoukei.co.jp/news/detail/387619",
+                "title": "道の駅で基本構想・基本計画／茂原市実施計画見直し／市民体育館を大改修／新市民会館はＰＦＩ調査 | 日本工業経済新聞社",
                 "url": "https://www.nikoukei.co.jp/news/detail/387619"
             },
             {
@@ -1973,7 +1973,7 @@
                 "url": "http://www.chibanippo.co.jp/news/local/140817"
             },
             {
-                "title": "https://www.city.oamishirasato.lg.jp/0000015324.html",
+                "title": "大網白里市道の駅整備の検討中止について | 大網白里市",
                 "url": "https://www.city.oamishirasato.lg.jp/0000015324.html"
             }
         ],
@@ -2009,7 +2009,7 @@
         "lng": 140.368552,
         "urls": [
             {
-                "title": "https://www.town.ichinomiya.chiba.jp/assets/files/gikaihou/gikaihou165.pdf",
+                "title": "一宮町議会だより 第165号（2017.11）",
                 "url": "https://www.town.ichinomiya.chiba.jp/assets/files/gikaihou/gikaihou165.pdf"
             },
             {
@@ -2029,7 +2029,7 @@
         "lng": 139.5297652,
         "urls": [
             {
-                "title": "https://www.city.higashikurume.lg.jp/shisei/jigyosha/1007219/1029031.html",
+                "title": "【公募終了・審査結果の公表】東久留米市道の駅基本構想策定支援業務委託に係る公募型プロポーザルを実施します",
                 "url": "https://www.city.higashikurume.lg.jp/shisei/jigyosha/1007219/1029031.html"
             }
         ],
@@ -2045,7 +2045,7 @@
         "lng": 139.3108944,
         "urls": [
             {
-                "title": "https://www.city.hamura.tokyo.jp/cmsfiles/contents/0000008/8018/siryou10.pdf",
+                "title": "【資料１０】羽村市まち・ひと・しごと創生計画事業",
                 "url": "https://www.city.hamura.tokyo.jp/cmsfiles/contents/0000008/8018/siryou10.pdf"
             }
         ],
@@ -2077,11 +2077,11 @@
         "lng": 139.3554014,
         "urls": [
             {
-                "title": "https://www.city.hiratsuka.kanagawa.jp/koen/page49_00091.html",
+                "title": "ひらつかシーテラス | 平塚市",
                 "url": "https://www.city.hiratsuka.kanagawa.jp/koen/page49_00091.html"
             },
             {
-                "title": "https://www.kanaloco.jp/news/government/entry-31633.html",
+                "title": "「道の駅」機能持たせず 平塚の公園整備で市 住環境に配慮 | 政治・行政 | カナロコ by 神奈川新聞",
                 "url": "https://www.kanaloco.jp/news/government/entry-31633.html"
             }
         ],
@@ -2097,11 +2097,11 @@
         "lng": 139.377762,
         "urls": [
             {
-                "title": "https://www.city.chigasaki.kanagawa.jp/machidukuri/1013542/index.html",
+                "title": "道の駅整備事業｜茅ヶ崎市",
                 "url": "https://www.city.chigasaki.kanagawa.jp/machidukuri/1013542/index.html"
             },
             {
-                "title": "https://m-shonanchigasaki.com/",
+                "title": "道の駅湘南ちがさき",
                 "url": "https://m-shonanchigasaki.com/"
             }
         ],
@@ -2129,7 +2129,7 @@
                 "url": "https://www.kanaloco.jp/news/government/article-1136619.html"
             },
             {
-                "title": "https://www.asahi.com/articles/AST2P421LT2PULOB015M.html",
+                "title": "綾瀬市が道の駅計画を見直しへ 市長「道の駅は活性化の手段の一つ」 [神奈川県]：朝日新聞",
                 "url": "https://www.asahi.com/articles/AST2P421LT2PULOB015M.html"
             },
             {
@@ -2197,7 +2197,7 @@
         "lng": 136.2507474,
         "urls": [
             {
-                "title": "https://www.city.awara.lg.jp/mokuteki/cityinfo/cityinfo01/cityinfo0101/p011916.html",
+                "title": "道の駅「蓮如の里あわら」基本計画を策定しました",
                 "url": "https://www.city.awara.lg.jp/mokuteki/cityinfo/cityinfo01/cityinfo0101/p011916.html"
             }
         ],
@@ -2229,11 +2229,11 @@
         "lng": 135.9353837,
         "urls": [
             {
-                "title": "https://hamabiyori.com/",
+                "title": "道の駅 若狭美浜はまびより - 福井県三方郡美浜町",
                 "url": "https://hamabiyori.com/"
             },
             {
-                "title": "https://urala.today/188790/",
+                "title": "美浜初のバー誕生へ ６月２日開業 道の駅「若狭美浜」 電気工事会社 飲食業に「挑戦」 | 日々URALA（ウララ）福井県のおすすめ情報",
                 "url": "https://urala.today/188790/"
             }
         ],
@@ -2253,11 +2253,11 @@
                 "url": "https://news.yahoo.co.jp/articles/803ad011ae91cd4f65dfce4e19209d2f705a446d"
             },
             {
-                "title": "https://www.minamialps-net.jp/cat_news/385450",
+                "title": "フモット 道の駅に 南ア市方針 ２７年度開業へ申請 | 南アルプスNET｜南アルプス市芦安山岳館",
                 "url": "https://www.minamialps-net.jp/cat_news/385450"
             },
             {
-                "title": "https://www.city.minami-alps.yamanashi.jp/docs/17021.html",
+                "title": "道の駅構想の策定について【fumotto（フモット）南アルプス】 - 山梨県 南アルプス市 -人がつどい 次世代につなぐ 活力あふれるまち-",
                 "url": "https://www.city.minami-alps.yamanashi.jp/docs/17021.html"
             }
         ],
@@ -2365,7 +2365,7 @@
                 "url": "https://www.town.sakuho.nagano.jp/oshirase/sogoseisakuka_2837.html"
             },
             {
-                "title": "https://www.mlit.go.jp/report/press/content/001723428.pdf",
+                "title": "「道の駅」の第６０回登録について",
                 "url": "https://www.mlit.go.jp/report/press/content/001723428.pdf"
             }
         ],
@@ -2381,11 +2381,11 @@
         "lng": 138.2137168,
         "urls": [
             {
-                "title": "https://www.mlit.go.jp/report/press/road01_hh_001635.html",
+                "title": "報道発表資料：「道の駅」の第５８回登録について～今回６駅が登録され、全国で１,２０４駅となります～ - 国土交通省",
                 "url": "https://www.mlit.go.jp/report/press/road01_hh_001635.html"
             },
             {
-                "title": "http://www.wadajuku-station.com/",
+                "title": "和田宿ステーション特産物直売所",
                 "url": "http://www.wadajuku-station.com/"
             }
         ],
@@ -2401,19 +2401,19 @@
         "lng": 137.9662549,
         "urls": [
             {
-                "title": "https://www.shinmai.co.jp/news/article/CNTS2024041100726",
+                "title": "「道の駅」登録も視野 「みのわテラス」をどう輝かせる 開業４年目、徐々に利用者増 箕輪町",
                 "url": "https://www.shinmai.co.jp/news/article/CNTS2024041100726"
             },
             {
-                "title": "https://www.shimin.co.jp/archives/9953",
+                "title": "みのわテラスを道の駅化 26年度中の登録目指し整備へ | 信州・市民新聞グループ",
                 "url": "https://www.shimin.co.jp/archives/9953"
             },
             {
-                "title": "https://ina-dani.net/topics/detail/?id=67651",
+                "title": "みのわテラス ２０２７年道の駅化目指す｜ニュース｜伊那谷ねっと",
                 "url": "https://ina-dani.net/topics/detail/?id=67651"
             },
             {
-                "title": "https://www.town.minowa.lg.jp/soshiki/midori_senryaku/gyomu/5/minowaterrace/index.html",
+                "title": "みのわテラス／箕輪町",
                 "url": "https://www.town.minowa.lg.jp/soshiki/midori_senryaku/gyomu/5/minowaterrace/index.html"
             }
         ],
@@ -2465,7 +2465,7 @@
         "lng": 137.3031676,
         "urls": [
             {
-                "title": "https://www.city.mizunami.lg.jp/kurashi/machizukuri/1001313/index.html",
+                "title": "道の駅",
                 "url": "https://www.city.mizunami.lg.jp/kurashi/machizukuri/1001313/index.html"
             }
         ],
@@ -2565,11 +2565,11 @@
         "lng": 137.8120703,
         "urls": [
             {
-                "title": "https://www.city.hamamatsu.shizuoka.jp/hk-shinko/event/r02/sounding.html",
+                "title": "新東名浜松浜北インターチェンジ周辺の「道の駅」整備に向けた民間事業者とのサウンディング型市場調査の実施について／浜松市",
                 "url": "https://www.city.hamamatsu.shizuoka.jp/hk-shinko/event/r02/sounding.html"
             },
             {
-                "title": "https://www.city.hamamatsu.shizuoka.jp/documents/105252/kohyo_1.pdf",
+                "title": "新東名浜松浜北インターチェンジ周辺の「道の駅」整備に向けた民間事業者の皆さまとのサウンディング型市場調査実施の結果について",
                 "url": "https://www.city.hamamatsu.shizuoka.jp/documents/105252/kohyo_1.pdf"
             }
         ],
@@ -2617,7 +2617,7 @@
         "lng": 138.204318,
         "urls": [
             {
-                "title": "https://www.city.fujieda.shizuoka.jp/soshiki/sports_bunka/chusankan/keikaku_torikumi/michinoeki_setoya_kihonkoso.html",
+                "title": "藤枝市「道の駅（仮）せとや」基本構想を策定しました／藤枝市ホームページ",
                 "url": "https://www.city.fujieda.shizuoka.jp/soshiki/sports_bunka/chusankan/keikaku_torikumi/michinoeki_setoya_kihonkoso.html"
             },
             {
@@ -2653,23 +2653,23 @@
         "lng": 138.216154,
         "urls": [
             {
-                "title": "https://www.city.makinohara.shizuoka.jp/soshiki/25/44325.html",
+                "title": "牧之原市「道の駅(仮)さかべ」基本構想を策定しました",
                 "url": "https://www.city.makinohara.shizuoka.jp/soshiki/25/44325.html"
             },
             {
-                "title": "http://yokotakaike.com/works-ja/%E3%80%90news%E3%80%912023-8-20-update-%E7%89%A7%E4%B9%8B%E5%8E%9F%E5%B8%82%E3%80%8C%E9%81%93%E3%81%AE%E9%A7%85%EF%BC%88%E4%BB%AE%EF%BC%89%E3%81%95%E3%81%8B%E3%81%B9%E3%80%8D%E3%81%AE%E5%9F%BA/",
+                "title": "【NEWS】2023.8.20 UPDATE /牧之原市「道の駅（仮）さかべ」の基本設計が完了しました！ « 高池葉子建築設計事務所",
                 "url": "http://yokotakaike.com/works-ja/%E3%80%90news%E3%80%912023-8-20-update-%E7%89%A7%E4%B9%8B%E5%8E%9F%E5%B8%82%E3%80%8C%E9%81%93%E3%81%AE%E9%A7%85%EF%BC%88%E4%BB%AE%EF%BC%89%E3%81%95%E3%81%8B%E3%81%B9%E3%80%8D%E3%81%AE%E5%9F%BA/"
             },
             {
-                "title": "https://www.city.makinohara.shizuoka.jp/soshiki/25/53215.html",
+                "title": "「道の駅」の名称が決定しました！",
                 "url": "https://www.city.makinohara.shizuoka.jp/soshiki/25/53215.html"
             },
             {
-                "title": "https://www.city.makinohara.shizuoka.jp/soshiki/21/55559.html",
+                "title": "道の駅オープニングスタッフ募集のお知らせ",
                 "url": "https://www.city.makinohara.shizuoka.jp/soshiki/21/55559.html"
             },
             {
-                "title": "https://www.city.makinohara.shizuoka.jp/soshiki/21/57995.html",
+                "title": "令和７年７月18日（金曜日）「道の駅そらっと牧之原」グランドオープン！",
                 "url": "https://www.city.makinohara.shizuoka.jp/soshiki/21/57995.html"
             }
         ],
@@ -2701,11 +2701,11 @@
         "lng": 137.0444198,
         "urls": [
             {
-                "title": "https://www.city.nisshin.lg.jp/department/sangyoseisaku/kikan/3/index.html",
+                "title": "道の駅整備事業／日進市",
                 "url": "https://www.city.nisshin.lg.jp/department/sangyoseisaku/kikan/3/index.html"
             },
             {
-                "title": "https://machi-terrace-nisshin.com/",
+                "title": "道の駅 マチテラス日進",
                 "url": "https://machi-terrace-nisshin.com/"
             }
         ],
@@ -2721,7 +2721,7 @@
         "lng": 136.6231912,
         "urls": [
             {
-                "title": "https://www.town.meiwa.mie.jp/material/files/group/45/toshimasusoan.pdf",
+                "title": "明和町都市計画マスタープラン（案）",
                 "url": "https://www.town.meiwa.mie.jp/material/files/group/45/toshimasusoan.pdf"
             }
         ],
@@ -2737,7 +2737,7 @@
         "lng": 135.954209,
         "urls": [
             {
-                "title": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001349092.pdf",
+                "title": "県・市管理公園の一体的Park-PFIによる「自転車の道の駅」等活性化調査 報告書",
                 "url": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001349092.pdf"
             },
             {
@@ -2777,7 +2777,7 @@
         "lng": 135.6085583,
         "urls": [
             {
-                "title": "https://www.city.tondabayashi.lg.jp/uploaded/attachment/79135.pdf",
+                "title": "富田林市農業公園の活性化に向けた新たな方向性",
                 "url": "https://www.city.tondabayashi.lg.jp/uploaded/attachment/79135.pdf"
             }
         ],
@@ -2797,7 +2797,7 @@
                 "url": "https://www.town.toyono.osaka.jp/data/doc/1542082424_doc_7_2.pdf"
             },
             {
-                "title": "https://www.town.toyono.osaka.jp/data/doc/1602561968_doc_228_6.pdf",
+                "title": "豊能町農×観光戦略推進計画の見直しについて",
                 "url": "https://www.town.toyono.osaka.jp/data/doc/1602561968_doc_228_6.pdf"
             }
         ],
@@ -2829,15 +2829,15 @@
         "lng": 134.7410907,
         "urls": [
             {
-                "title": "https://www.city.himeji.lg.jp/sangyo/0000015054.html",
+                "title": "「（仮称）道の駅姫路」整備基本構想のリリース | 姫路市",
                 "url": "https://www.city.himeji.lg.jp/sangyo/0000015054.html"
             },
             {
-                "title": "https://www.city.himeji.lg.jp/sangyo/category/4-2-9-0-0-0-0-0-0-0.html",
+                "title": "道の駅 | 姫路市",
                 "url": "https://www.city.himeji.lg.jp/sangyo/category/4-2-9-0-0-0-0-0-0-0.html"
             },
             {
-                "title": "https://www.city.himeji.lg.jp/sangyo/0000027700.html",
+                "title": "「（仮称）道の駅姫路」整備事業 | 姫路市",
                 "url": "https://www.city.himeji.lg.jp/sangyo/0000027700.html"
             },
             {
@@ -2901,15 +2901,15 @@
         "lng": 135.12254,
         "urls": [
             {
-                "title": "https://www.city.miki.lg.jp/soshiki/33/34882.html",
+                "title": "吉川地域の核「山田錦の郷」の活性化をめざして",
                 "url": "https://www.city.miki.lg.jp/soshiki/33/34882.html"
             },
             {
-                "title": "https://www.city.miki.lg.jp/soshiki/33/60531.html",
+                "title": "新しく開駅を目指す「道の駅」名称が決定しました！",
                 "url": "https://www.city.miki.lg.jp/soshiki/33/60531.html"
             },
             {
-                "title": "https://www.kobe-np.co.jp/news/miki/202501/0018594863.shtml",
+                "title": "「道の駅よかわ」4月22日開業決定 開駅式で鏡開きや和太鼓演奏 駐車場拡張し236台分確保|三木|神戸新聞NEXT",
                 "url": "https://www.kobe-np.co.jp/news/miki/202501/0018594863.shtml"
             }
         ],
@@ -2925,11 +2925,11 @@
         "lng": 134.8662683,
         "urls": [
             {
-                "title": "https://www.city.kasai.hyogo.jp/site/keikaku-sesaku/27014.html",
+                "title": "道の駅基本構想の策定",
                 "url": "https://www.city.kasai.hyogo.jp/site/keikaku-sesaku/27014.html"
             },
             {
-                "title": "https://project.nikkeibp.co.jp/atclppp/PPP/news/122702723/",
+                "title": "歴史遺産のフィールドミュージアムに道の駅、加西市がサウンディング｜新・公民連携最前線｜PPPまちづくり",
                 "url": "https://project.nikkeibp.co.jp/atclppp/PPP/news/122702723/"
             }
         ],
@@ -2945,19 +2945,19 @@
         "lng": 135.1050564,
         "urls": [
             {
-                "title": "https://www.kobe-np.co.jp/news/tanba/202209/0015642733.shtml",
+                "title": "丹波篠山市、こんだ薬師温泉を「道の駅」として整備へ ２０２６年の開業目指す | 丹波 | 神戸新聞NEXT",
                 "url": "https://www.kobe-np.co.jp/news/tanba/202209/0015642733.shtml"
             },
             {
-                "title": "https://tanba.jp/2024/09/%E7%B7%8F%E4%BA%8B%E6%A5%AD%E8%B2%BB%E7%B4%842%E3%83%BB6%E5%84%84%E6%83%B3%E5%AE%9A%E3%80%80%E6%B8%A9%E6%B5%B4%E6%96%BD%E8%A8%AD%E3%82%92%E3%80%8C%E9%81%93%E3%81%AE%E9%A7%85%E3%80%8D%E3%81%AB%E3%80%80/",
+                "title": "総事業費約2・6億想定 温浴施設を「道の駅」に 農産物直売所や広場造成 - 丹波新聞",
                 "url": "https://tanba.jp/2024/09/%E7%B7%8F%E4%BA%8B%E6%A5%AD%E8%B2%BB%E7%B4%842%E3%83%BB6%E5%84%84%E6%83%B3%E5%AE%9A%E3%80%80%E6%B8%A9%E6%B5%B4%E6%96%BD%E8%A8%AD%E3%82%92%E3%80%8C%E9%81%93%E3%81%AE%E9%A7%85%E3%80%8D%E3%81%AB%E3%80%80/"
             },
             {
-                "title": "https://www.kobe-np.co.jp/news/tanba/202602/0020058834.shtml",
+                "title": "丹波篠山「こんだ温泉ぬくもりの郷」 道の駅へ改修、パース図公開 27年3月オープン目指す|丹波|神戸新聞NEXT",
                 "url": "https://www.kobe-np.co.jp/news/tanba/202602/0020058834.shtml"
             },
             {
-                "title": "https://www.city.tambasasayama.lg.jp/soshikikarasagasu/chiikiseibika/28330.html",
+                "title": "道の駅に関すること／丹波篠山市",
                 "url": "https://www.city.tambasasayama.lg.jp/soshikikarasagasu/chiikiseibika/28330.html"
             }
         ],
@@ -2985,11 +2985,11 @@
                 "url": "https://www.pref.nara.jp/secure/294589/chirashi.pdf"
             },
             {
-                "title": "https://michi-no-eki-crosswaynakamachi.pref.nara.jp/",
+                "title": "道の駅クロスウェイなかまち",
                 "url": "https://michi-no-eki-crosswaynakamachi.pref.nara.jp/"
             },
             {
-                "title": "https://michi-no-eki-crosswaynakamachi.pref.nara.jp/2024/03/26/%E3%82%AA%E3%83%BC%E3%83%97%E3%83%B3%E5%BB%B6%E6%9C%9F%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6/",
+                "title": "オープン延期について – 道の駅クロスウェイなかまち",
                 "url": "https://michi-no-eki-crosswaynakamachi.pref.nara.jp/2024/03/26/%E3%82%AA%E3%83%BC%E3%83%97%E3%83%B3%E5%BB%B6%E6%9C%9F%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6/"
             }
         ],
@@ -3005,7 +3005,7 @@
         "lng": 135.9624012,
         "urls": [
             {
-                "title": "https://www.vill.shimokitayama.nara.jp/oshirase/2026/06/0000718.html",
+                "title": "道の駅「きなりの郷 下北山」が7/6(月)にオープンします！",
                 "url": "https://www.vill.shimokitayama.nara.jp/oshirase/2026/06/0000718.html"
             }
         ],
@@ -3037,11 +3037,11 @@
         "lng": 135.1698486,
         "urls": [
             {
-                "title": "https://www.city.kainan.lg.jp/kakubusho/machizukuribu/norinsuisangakari/michinoeki/index.html",
+                "title": "道の駅「海南サクアス」について／海南市",
                 "url": "https://www.city.kainan.lg.jp/kakubusho/machizukuribu/norinsuisangakari/michinoeki/index.html"
             },
             {
-                "title": "https://sakuas.com/",
+                "title": "道の駅 海南サクアス | 和歌山県海南市に誕生 みかん山に囲まれた魚が美味しい道の駅",
                 "url": "https://sakuas.com/"
             }
         ],
@@ -3141,7 +3141,7 @@
         "lng": 134.4772181,
         "urls": [
             {
-                "title": "https://www.city.tokushima.tokushima.jp/shisei/machi_keikaku/economy_sightseeing/michinoeki_iinkai/01tiikisinkousisetu.files/06siryou6.pdf",
+                "title": "資料６ 地域振興施設（国府道の駅）について",
                 "url": "https://www.city.tokushima.tokushima.jp/shisei/machi_keikaku/economy_sightseeing/michinoeki_iinkai/01tiikisinkousisetu.files/06siryou6.pdf"
             },
             {
@@ -3261,7 +3261,7 @@
         "lng": 133.644,
         "urls": [
             {
-                "title": "https://www.city.kanonji.kagawa.jp/soshiki/54/43717.html",
+                "title": "新「道の駅」かんおんじ（仮称）基本構想の策定について - 観音寺市",
                 "url": "https://www.city.kanonji.kagawa.jp/soshiki/54/43717.html"
             },
             {
@@ -3301,7 +3301,7 @@
         "lng": 134.2949958,
         "urls": [
             {
-                "title": "https://michinoeki-toyocho.jp/",
+                "title": "【公式】道の駅 東洋町 | 海まで徒歩0分の道の駅",
                 "url": "https://michinoeki-toyocho.jp/"
             }
         ],
@@ -3317,7 +3317,7 @@
         "lng": 133.3172333,
         "urls": [
             {
-                "title": "https://www.town.sakawa.lg.jp/life/dtl.php?hdnKey=2009",
+                "title": "佐川町道の駅「基本計画」が策定されました | 佐川町役場",
                 "url": "https://www.town.sakawa.lg.jp/life/dtl.php?hdnKey=2009"
             },
             {
@@ -3329,7 +3329,7 @@
                 "url": "https://niyodoblue.jp/event/detail.php?id=183"
             },
             {
-                "title": "https://www.town.sakawa.lg.jp/file/?t=LD&id=2522&fid=13995",
+                "title": "「ハナサクサカワ」おもてなしの準備ご紹介",
                 "url": "https://www.town.sakawa.lg.jp/file/?t=LD&id=2522&fid=13995"
             }
         ],
@@ -3345,7 +3345,7 @@
         "lng": 130.3558207,
         "urls": [
             {
-                "title": "https://www.city.okawa.lg.jp/100/050/070/20201019143355.html",
+                "title": "「大川の駅」整備事業 - 大川市",
                 "url": "https://www.city.okawa.lg.jp/100/050/070/20201019143355.html"
             }
         ],
@@ -3361,11 +3361,11 @@
         "lng": 130.4834248,
         "urls": [
             {
-                "title": "https://www.city.koga.fukuoka.jp/uploads/source/shoukou/%E9%81%93%E3%81%AE%E9%A7%85/kihonkeikakugaiyouban.pdf",
+                "title": "古賀市道の駅基本計画（暫定案）－概要版－",
                 "url": "https://www.city.koga.fukuoka.jp/uploads/source/shoukou/%E9%81%93%E3%81%AE%E9%A7%85/kihonkeikakugaiyouban.pdf"
             },
             {
-                "title": "https://www.city.koga.fukuoka.jp/blog/item/3306",
+                "title": "道の駅の整備可否の方針決定と今後の方向性について(8月26日)｜ 市長室ブログ｜ ようこそ市長室へ｜ 古賀市オフィシャルページ",
                 "url": "https://www.city.koga.fukuoka.jp/blog/item/3306"
             }
         ],
@@ -3381,11 +3381,11 @@
         "lng": 130.8073248,
         "urls": [
             {
-                "title": "https://www.town-kawasaki.com/important/26667",
+                "title": "川崎町「道の駅」基本構想・基本計画 ｜ ReBorn！KAWASAKIMACHI：福岡県田川郡川崎町",
                 "url": "https://www.town-kawasaki.com/important/26667"
             },
             {
-                "title": "https://www.nishinippon.co.jp/item/n/589017/",
+                "title": "川崎町が道の駅新設 「パン博の町」前面に 新年度に基本計画｜【西日本新聞me】",
                 "url": "https://www.nishinippon.co.jp/item/n/589017/"
             },
             {
@@ -3393,15 +3393,15 @@
                 "url": "https://www.instagram.com/kawasaki_michinoeki/"
             },
             {
-                "title": "https://www.nishinippon.co.jp/item/1313693/",
+                "title": "「パンでまちおこし」福岡・川崎町、地元産野菜などで「道の駅」の商品を検討｜【西日本新聞me】",
                 "url": "https://www.nishinippon.co.jp/item/1313693/"
             },
             {
-                "title": "https://www.town-kawasaki.com/important/352288",
+                "title": "一般競争入札の公告について 令和8・9・１０年度（継続費）川崎町道の駅整備工事 ｜ ReBorn！KAWASAKIMACHI：福岡県田川郡川崎町",
                 "url": "https://www.town-kawasaki.com/important/352288"
             },
             {
-                "title": "https://www.town-kawasaki.com/important/336874",
+                "title": "川崎町「道の駅」の名称を募集します！ ｜ ReBorn！KAWASAKIMACHI：福岡県田川郡川崎町",
                 "url": "https://www.town-kawasaki.com/important/336874"
             }
         ],
@@ -3417,15 +3417,15 @@
         "lng": 130.4169004,
         "urls": [
             {
-                "title": "https://www.town.kamimine.lg.jp/kiji003186/index.html",
+                "title": "上峰町地域振興施設基本構想の策定について / 上峰町ホームページ",
                 "url": "https://www.town.kamimine.lg.jp/kiji003186/index.html"
             },
             {
-                "title": "https://www.asahi.com/articles/ASP806WQYP8YTGPB002.html",
+                "title": "旧イオン一帯の再開発が始動 年度内に解体へ 上峰町 [佐賀県]：朝日新聞",
                 "url": "https://www.asahi.com/articles/ASP806WQYP8YTGPB002.html"
             },
             {
-                "title": "https://www.sagatv.co.jp/news/archives/2024101418018",
+                "title": "道の駅「かみみね」に国から登録証 県内で11カ所目【佐賀県】｜佐賀のニュース｜サガテレビ",
                 "url": "https://www.sagatv.co.jp/news/archives/2024101418018"
             }
         ],
@@ -3441,7 +3441,7 @@
         "lng": 130.0456585,
         "urls": [
             {
-                "title": "https://www.city.isahaya.nagasaki.jp/post32/97230.html",
+                "title": "諫早市「（仮称）道の駅251」整備事業 - 諫早市",
                 "url": "https://www.city.isahaya.nagasaki.jp/post32/97230.html"
             }
         ],
@@ -3461,7 +3461,7 @@
                 "url": "https://www.city.yatsushiro.lg.jp/kiji00319890/3_19890_103930_up_r0vngwjk.pdf"
             },
             {
-                "title": "https://www.city.yatsushiro.lg.jp/kiji00323699/index.html",
+                "title": "道の駅坂本の再整備に係る進捗について / 熊本県八代市",
                 "url": "https://www.city.yatsushiro.lg.jp/kiji00323699/index.html"
             }
         ],
@@ -3477,15 +3477,15 @@
         "lng": 130.4289861,
         "urls": [
             {
-                "title": "https://www.city.arao.lg.jp/shisei/shisaku/wellness/michinoeki/",
+                "title": "道の駅ウェルネスあらお - 荒尾市",
                 "url": "https://www.city.arao.lg.jp/shisei/shisaku/wellness/michinoeki/"
             },
             {
-                "title": "https://www.midori-gr.com/arao/",
+                "title": "道の駅ウェルネスあらお | 熊本県荒尾市の観光・交流拠点",
                 "url": "https://www.midori-gr.com/arao/"
             },
             {
-                "title": "https://wellness-arao.com/",
+                "title": "道の駅ウェルネスあらお | 熊本県荒尾市の観光・交流拠点",
                 "url": "https://wellness-arao.com/"
             }
         ],
@@ -3505,7 +3505,7 @@
                 "url": "http://www.yatsushiro.org/VOICES/CGI/voiweb.exe?ACT=200&KENSAKU=0&SORT=0&KTYP=2,3&KGTP=1,2&TITL_SUBT=%97%DF%98a%81@%82R%94N%82P%82Q%8C%8E%92%E8%97%E1%89%EF%81%7C12%8C%8E09%93%FA-04%8D%86&KGNO=203&FINO=889"
             },
             {
-                "title": "https://www.city.yatsushiro.lg.jp/gikai/kiji00320732/index.html",
+                "title": "令和5年9月定例会 / 市議会TOP / 熊本県八代市",
                 "url": "https://www.city.yatsushiro.lg.jp/gikai/kiji00320732/index.html"
             },
             {
@@ -3549,7 +3549,7 @@
                 "url": "https://www.city.oita.oita.jp/o243/machizukuri/seibukaigan_implementation_policy_plan.html"
             },
             {
-                "title": "https://www.tanourara.jp/",
+                "title": "道の駅たのうらら 大分市",
                 "url": "https://www.tanourara.jp/"
             },
             {
@@ -3645,11 +3645,11 @@
         "lng": 130.3531905,
         "urls": [
             {
-                "title": "https://www.city.kagoshima-izumi.lg.jp/page/page_06970.html",
+                "title": "南九州西回り自動車道の建設促進、北薩横断道路・防災道の駅「出水」の整備促進要望活動（令和４年１０月２６日） ｜鹿児島県出水市 みんなでつくる活力都市 住みたいまち 出水市",
                 "url": "https://www.city.kagoshima-izumi.lg.jp/page/page_06970.html"
             },
             {
-                "title": "https://project.nikkeibp.co.jp/atclppp/PPP/news/112103157/",
+                "title": "道の駅新設･運営のPPP手法についてサウンディング、出水市｜新・公民連携最前線｜PPPまちづくり",
                 "url": "https://project.nikkeibp.co.jp/atclppp/PPP/news/112103157/"
             },
             {
@@ -3669,7 +3669,7 @@
         "lng": 130.9023299,
         "urls": [
             {
-                "title": "http://www.town.minamitane.kagoshima.jp/assets/files/pdf/kikaku/20250321_paburikkukomennto.pdf",
+                "title": "令和６年度 南種子町観光物産館道の駅基本構想 パブリックコメント版",
                 "url": "http://www.town.minamitane.kagoshima.jp/assets/files/pdf/kikaku/20250321_paburikkukomennto.pdf"
             }
         ],
@@ -3685,7 +3685,7 @@
         "lng": 128.9511518,
         "urls": [
             {
-                "title": "https://amamishimbun.co.jp/2023/02/15/42368/",
+                "title": "観光拠点施設 24年12月オープンへ – 奄美新聞",
                 "url": "https://amamishimbun.co.jp/2023/02/15/42368/"
             },
             {
@@ -3705,7 +3705,7 @@
         "lng": 124.1555837,
         "urls": [
             {
-                "title": "https://www.city.ishigaki.okinawa.jp/material/files/group/11/zenkikihonkeikaku.pdf",
+                "title": "第５次石垣市総合計画 前期基本計画",
                 "url": "https://www.city.ishigaki.okinawa.jp/material/files/group/11/zenkikihonkeikaku.pdf"
             },
             {
@@ -3725,19 +3725,19 @@
         "lng": 127.8833393,
         "urls": [
             {
-                "title": "https://www8.cao.go.jp/okinawa/8/2025/0401_hokubu.pdf",
+                "title": "令和７年度北部振興事業の実施について（第１回）",
                 "url": "https://www8.cao.go.jp/okinawa/8/2025/0401_hokubu.pdf"
             },
             {
-                "title": "https://www.okinawatimes.co.jp/articles/-/1573997",
+                "title": "沖縄・本部町に「道の駅」2026年度に着工へ 海を見ながらBBQ・ビアガーデンも 交通の結節点で町の魅力発信 | 沖縄タイムス＋プラス",
                 "url": "https://www.okinawatimes.co.jp/articles/-/1573997"
             },
             {
-                "title": "https://www.okinawatimes.co.jp/articles/-/1877294",
+                "title": "沖縄・本部に新しい道の駅 「もとぶオアシス」9月着工へ 2028年度供用目指す | 沖縄タイムス＋プラス",
                 "url": "https://www.okinawatimes.co.jp/articles/-/1877294"
             },
             {
-                "title": "https://ryukyushimpo.jp/national/entry-5366680.html",
+                "title": "もとぶオアシス9月着工 大浜に道の駅、28年度開始へ 沖縄",
                 "url": "https://ryukyushimpo.jp/national/entry-5366680.html"
             }
         ],


### PR DESCRIPTION
## 変更内容

`data/plans.json` の出典リンクのうち、`title` が URL 文字列のままだった 300 件を調査し、**215 件**を出典ページ自身のタイトルに差し替えた（122 レコード）。

- **HTML**: ページを実際に取得して `<title>` を採用（文字コードは `Content-Type` / `meta` から判定して Shift_JIS・EUC-JP も復号、HTML エンティティはデコード）
- **PDF**: `/Title` メタデータが `PowerPoint プレゼンテーション` のような定型文の場合は 1 ページ目のテキスト（`pdftotext`）から文書名を採った
- サイト名の定型サフィックス（`…ホームページ` / `公式サイト` など）だけを機械的に落とし、報道機関名は残している

## URL のまま残した 85 件

- ページが消えている（404 / 403。新聞社・NHK ローカルニュースなど）
- 到達できてもページがラベルにならない: Instagram の投稿、記事が残っていない新聞サイトの当日ニュース一覧、任意のスラッグでトップページを返すポータル、テキストを持たない画像のみの PDF

いずれも「アクセスできないものはそのままにする」方針で URL を維持した。

## checked_on について

**意図的に据え置いている。** 今回はリンクのラベル補完で計画の再調査ではないため、`checked_on` を進めると `checked_on` 昇順の調査キュー（`docs/plan-map.md`）に実際には調べていない 122 件が最後尾に回り、約 12 セッション分順序が狂う。`npm run plan -- url title` は全書き込みで当日を打刻する設計なので、`src/lib/plan-master.ts` の `setUrlTitle` + `savePlans` を通して書き込んだ（ファイルの正規形は CLI と同一）。

## 確認

- `git diff` の変更行は `title` のみ（215 行の入れ替え、`checked_on` を含む他の列は無変更）
- `npm test`（387 件）/ `npm run lint` / `npm run typecheck` / `npx biome check data/plans.json` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
