### PR TITLE
Enable Biome's types domain

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,6 +14,9 @@
     },
     "linter": {
         "enabled": true,
+        "domains": {
+            "types": "all"
+        },
         "rules": {
             "preset": "recommended",
             "complexity": {
@@ -41,7 +44,15 @@
                 "noUselessElse": "error"
             },
             "suspicious": {
-                "noExplicitAny": "warn"
+                "noExplicitAny": "warn",
+                // Off until Biome's type inference stops reporting guards that
+                // are actually required. Deleting a flagged guard produces a
+                // null dereference at runtime, so the rule cannot be acted on
+                // as it stands.
+                // https://github.com/biomejs/biome/issues/11360 - useRef(...).current
+                // https://github.com/biomejs/biome/issues/11278 - RegExp.exec()
+                // https://github.com/biomejs/biome/issues/10781 - optional chaining
+                "noUnnecessaryConditions": "off"
             }
         }
     },

--- a/src/frontend/storage/remote-storage.test.ts
+++ b/src/frontend/storage/remote-storage.test.ts
@@ -28,7 +28,7 @@ describe('RemoteStorage', () => {
         expect(storage.getItem('111')).toBe('1');
         expect(storage.getItem('222')).toBe('3');
         expect(storage.getItem('unknown')).toBeNull();
-        expect(storage.listItems().sort()).toEqual(['111', '222']);
+        expect(storage.listItems().sort((a, b) => a.localeCompare(b))).toEqual(['111', '222']);
     });
 
     it('returns updates synchronously from the cache', async () => {

--- a/src/frontend/style.test.ts
+++ b/src/frontend/style.test.ts
@@ -72,7 +72,7 @@ describe('entries', () => {
         storage.setItem('001', '1');
         storage.setItem('002', '4');
 
-        expect(entries(storage).sort()).toEqual([
+        expect(entries(storage).sort((a, b) => a[0].localeCompare(b[0]))).toEqual([
             ['001', 1],
             ['002', 4],
         ]);


### PR DESCRIPTION
Adds `linter.domains: { "types": "all" }`, following [tk0miya/skills](https://github.com/tk0miya/skills) commit `f843982` ("Enable Biome's types domain in the TypeScript template").

Rules that need type inference — `noFloatingPromises` and friends — stay off unless the types domain is turned on. `"all"` rather than `"recommended"` matches the strict stance the template already takes with tsconfig's `"strict": true`.

### noUnnecessaryConditions is disabled with it

The domain also switches on `noUnnecessaryConditions`, whose type inference is unsound in shapes this repo uses. It reported ~13 guards that are all genuinely required — for example `src/frontend/components/RoadStationMap.tsx` L34, where `mapContainerRef` is declared `useRef<HTMLDivElement | null>(null)` on L24 and the guard is reported as "always **falsy**". Acting on that one would stop the map from initialising at all. The same construct in mapphoto is reported as "always **truthy**", which is the clearest sign the inference cannot be trusted here.

Upstream issues, linked from the config as comments:

- https://github.com/biomejs/biome/issues/11360 — `useRef(...).current` null-guards, a regression in 2.5.6 (still present in 2.5.9; closed `not_planned` without a fix)
- https://github.com/biomejs/biome/issues/11278 — `RegExp.prototype.exec()` treated as non-nullable
- https://github.com/biomejs/biome/issues/10781 — optional chaining

### biome.json → biome.jsonc

`biome.json` rejects comments — adding them makes Biome fall back to its defaults silently, which drops `files.includes` and starts linting `.claude/`, `html/js/` and friends. `.jsonc` is the supported way to keep the reasoning next to the setting. `biome migrate --write` leaves the file untouched, so the Biome migrate workflow is unaffected.

### useArraySortCompare

The domain's other new findings are real, so they are fixed rather than silenced: `src/frontend/style.test.ts` and `src/frontend/storage/remote-storage.test.ts` now sort with an explicit comparator instead of relying on `Array#sort`'s default string ordering.

`npm run lint` is back to the 18 warnings it had before this change, `npm run typecheck` passes, and `npm test` passes except for `src/scripts/generate-stationlist.test.ts`, which fetches michi-no-eki.jp and cannot reach the network in my sandbox.