### PR TITLE
Move the route button below the map-type controls and match their look

### DIFF
--- a/html/css/basic.css
+++ b/html/css/basic.css
@@ -12,7 +12,11 @@ body,
     padding: 0px;
 }
 
-div.share {
+/* The share button and the route button. They follow the look of the controls
+   the Maps API draws in the same corner — the map-type buttons — rather than
+   announcing themselves against them. */
+div.share,
+div.route-button {
     margin-top: 10px;
     padding: 0 17px;
     height: 40px;
@@ -25,27 +29,14 @@ div.share {
     color: rgb(86, 86, 86);
 }
 
-div.share:hover {
+div.share:hover,
+div.route-button:hover {
     background-color: rgb(235, 235, 235);
 }
 
+/* Alone in its control position, which starts at the map's own edge. */
 div.route-button {
-    margin-top: 10px;
-    padding: 0 20px;
-    height: 44px;
-    line-height: 44px;
-    cursor: pointer;
-    background-color: #1a73e8;
-    box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
-    font-family: Roboto, Arial, sans-serif;
-    font-size: 16px;
-    font-weight: bold;
-    color: white;
-    border-radius: 2px;
-}
-
-div.route-button:hover {
-    background-color: #1558b8;
+    margin-left: 10px;
 }
 
 /* The state of the route being built. One line, held near the bottom of the

--- a/src/frontend/components/RouteModeButton.test.tsx
+++ b/src/frontend/components/RouteModeButton.test.tsx
@@ -18,16 +18,16 @@ describe('RouteModeButton', () => {
         cleanup();
     });
 
-    const topCenter = (mockMap: ReturnType<typeof createMockMap>) =>
-        mockMap.controls[google.maps.ControlPosition.TOP_CENTER].getArray();
+    const leftTop = (mockMap: ReturnType<typeof createMockMap>) =>
+        mockMap.controls[google.maps.ControlPosition.LEFT_TOP].getArray();
 
-    it('mounts a button into TOP_CENTER controls', () => {
+    it('mounts a button into LEFT_TOP controls', () => {
         const mockMap = createMockMap();
 
         render(<RouteModeButton map={mockMap} visible={true} onClick={() => {}} />);
 
-        expect(topCenter(mockMap)).toHaveLength(1);
-        expect(topCenter(mockMap)[0].textContent).toBe('ルート');
+        expect(leftTop(mockMap)).toHaveLength(1);
+        expect(leftTop(mockMap)[0].textContent).toBe('ルート');
     });
 
     it('renders nothing while hidden', () => {
@@ -35,7 +35,7 @@ describe('RouteModeButton', () => {
 
         render(<RouteModeButton map={mockMap} visible={false} onClick={() => {}} />);
 
-        expect(topCenter(mockMap)).toHaveLength(0);
+        expect(leftTop(mockMap)).toHaveLength(0);
     });
 
     it('reports a click', () => {
@@ -43,7 +43,7 @@ describe('RouteModeButton', () => {
         const onClick = vi.fn();
 
         render(<RouteModeButton map={mockMap} visible={true} onClick={onClick} />);
-        topCenter(mockMap)[0].click();
+        leftTop(mockMap)[0].click();
 
         expect(onClick).toHaveBeenCalledTimes(1);
     });
@@ -52,11 +52,11 @@ describe('RouteModeButton', () => {
         const mockMap = createMockMap();
 
         const { rerender } = render(<RouteModeButton map={mockMap} visible={true} onClick={() => {}} />);
-        expect(topCenter(mockMap)).toHaveLength(1);
+        expect(leftTop(mockMap)).toHaveLength(1);
 
         rerender(<RouteModeButton map={mockMap} visible={false} onClick={() => {}} />);
 
-        expect(topCenter(mockMap)).toHaveLength(0);
+        expect(leftTop(mockMap)).toHaveLength(0);
     });
 
     it('reaches the latest handler after a re-render', () => {
@@ -66,7 +66,7 @@ describe('RouteModeButton', () => {
 
         const { rerender } = render(<RouteModeButton map={mockMap} visible={true} onClick={first} />);
         rerender(<RouteModeButton map={mockMap} visible={true} onClick={second} />);
-        topCenter(mockMap)[0].click();
+        leftTop(mockMap)[0].click();
 
         expect(first).not.toHaveBeenCalled();
         expect(second).toHaveBeenCalledTimes(1);

--- a/src/frontend/components/RouteModeButton.tsx
+++ b/src/frontend/components/RouteModeButton.tsx
@@ -26,7 +26,10 @@ export function RouteModeButton(props: RouteModeButtonProps) {
         const onClick = () => onClickRef.current();
         div.addEventListener('click', onClick);
 
-        const controls = props.map.controls[google.maps.ControlPosition.TOP_CENTER];
+        // LEFT_TOP, not TOP_LEFT: it stacks the button below the row the
+        // map-type and share buttons flow into, rather than joining that row and
+        // competing with them for width on a narrow screen.
+        const controls = props.map.controls[google.maps.ControlPosition.LEFT_TOP];
         controls.push(div);
 
         return () => {

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -29,6 +29,7 @@ export const createMockMap = () => {
     const topLeftControls: HTMLElement[] = [];
     const topCenterControls: HTMLElement[] = [];
     const topRightControls: HTMLElement[] = [];
+    const leftTopControls: HTMLElement[] = [];
     const rightTopControls: HTMLElement[] = [];
 
     const controls = {
@@ -49,6 +50,12 @@ export const createMockMap = () => {
             push: vi.fn((element: HTMLElement) => topRightControls.push(element)),
             removeAt: vi.fn((index: number) => topRightControls.splice(index, 1)),
             getArray: vi.fn(() => topRightControls),
+        },
+        // LEFT_TOP
+        5: {
+            push: vi.fn((element: HTMLElement) => leftTopControls.push(element)),
+            removeAt: vi.fn((index: number) => leftTopControls.splice(index, 1)),
+            getArray: vi.fn(() => leftTopControls),
         },
         // RIGHT_TOP
         7: {
@@ -177,6 +184,7 @@ export const setupGoogleMapsMock = () => {
                 TOP_LEFT: 1,
                 TOP_CENTER: 2,
                 TOP_RIGHT: 3,
+                LEFT_TOP: 5,
                 RIGHT_TOP: 7,
             },
             Size: class {


### PR DESCRIPTION
## Summary

The route button sat in the map's `TOP_CENTER` controls, which left it standing on its own in the middle of the screen on a desktop and overlapping the share button on a phone. Its blue fill also set it apart from every other control in that corner. It now sits with those controls and looks like them.

## Changes

- **Position** (`src/frontend/components/RouteModeButton.tsx`): `ControlPosition.TOP_CENTER` → `LEFT_TOP`. `LEFT_TOP` stacks the button below the row that the map-type control and the share button flow into, rather than joining that row and competing with them for width on a narrow screen.

- **Look** (`html/css/basic.css`): `div.route-button` now shares one rule with `div.share` — white fill, the grey type and the metrics of the controls the Maps API draws in the same corner. The blue fill, bold weight and `border-radius` are gone. A separate one-property rule gives the route button `margin-left: 10px`: unlike the share button, which the map-type control carries in from the edge ahead of it, this button has its control position to itself and that position starts at the map's own edge.

- **Tests**: `src/test-utils/test-utils.ts` gains the `LEFT_TOP` control array and enum entry; `RouteModeButton.test.tsx` reads that position instead of `TOP_CENTER`. No test cases were added or removed.

## Note on the button's height

Matching the neighbouring controls makes the button **40px tall rather than 44px**. That was not part of the request — the request was position and colour — but the map-type buttons and the share button beside it are 40px, and a different height in the same column would read as a mistake. The buttons inside the route bar keep their 44px, since they are not part of the map's control cluster. Say the word if the tap target should win over the alignment and it can go back to 44px.

## Verification

`npm run lint` (19 warnings, same count as master) / `npm run typecheck` / `npm test` (396 passed, 6 skipped).

The placement was **not verified on a real map**: the Google Maps API cannot be loaded from this environment's browser. It was checked by rendering the real CSS against a stand-in that models the `LEFT_TOP` control container starting at the map's left edge, which is where the first attempt was found to leave the button 10px out of line with the row above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLomoY28HmLrdhTG6v8MjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLomoY28HmLrdhTG6v8MjS)_