### PR TITLE
Trim the LEFT_TOP comment to the Maps API fact it is there for

### DIFF
--- a/src/frontend/components/RouteModeButton.tsx
+++ b/src/frontend/components/RouteModeButton.tsx
@@ -26,9 +26,8 @@ export function RouteModeButton(props: RouteModeButtonProps) {
         const onClick = () => onClickRef.current();
         div.addEventListener('click', onClick);
 
-        // LEFT_TOP, not TOP_LEFT: it stacks the button below the row the
-        // map-type and share buttons flow into, rather than joining that row and
-        // competing with them for width on a narrow screen.
+        // LEFT_TOP, not TOP_LEFT: it puts the control on the left edge below the
+        // TOP_LEFT row instead of inside it.
         const controls = props.map.controls[google.maps.ControlPosition.LEFT_TOP];
         controls.push(div);
 


### PR DESCRIPTION
## Summary

The comment above the route button's control position said two things: what `LEFT_TOP` is, and why that position was chosen over joining the `TOP_LEFT` row. The second belongs to the history of #389, not to the code, so it is gone.

```diff
-        // LEFT_TOP, not TOP_LEFT: it stacks the button below the row the
-        // map-type and share buttons flow into, rather than joining that row and
-        // competing with them for width on a narrow screen.
+        // LEFT_TOP, not TOP_LEFT: it puts the control on the left edge below the
+        // TOP_LEFT row instead of inside it.
```

## Why anything is left at all

`LEFT_TOP` and `TOP_LEFT` are near-identical names for different positions, and nothing in the type system distinguishes them. Read as the same constant, `LEFT_TOP` looks like a typo worth "fixing" — and `TOP_LEFT` is exactly where the button overlapped the share button on a phone before #389. The remaining two lines state only that API fact, which is what a reader cannot get from the names.

## Verification

Comment only — no behaviour changes and no test changes. `npm run lint` (19 warnings, same count as master) / `npm run typecheck` / `npm test` (396 passed, 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLomoY28HmLrdhTG6v8MjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLomoY28HmLrdhTG6v8MjS)_