### PR TITLE
Lay the route panel out in one row

### DIFF
--- a/html/css/basic.css
+++ b/html/css/basic.css
@@ -61,37 +61,40 @@ button.route-control-enter:hover {
 }
 
 /* In route mode the same box opens onto the state of the route being built.
-   Stacked rather than set in a row: the box grows downward out of the corner it
-   already holds, so it takes no more of the map's width than the column above
-   it, and the reader's eye stays where the button was. */
+   One row deep, growing to the right out of the corner it already holds. The
+   row has to end before the legend at the map's other corner, and the legend is
+   pinned to the right edge, so the budget shrinks with the screen: 285px on a
+   375px phone, against the 266px this row measures — which is what the short
+   "作成" label buys. Below about 360px the two would meet. */
 div.route-control-panel {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 8px;
-    min-width: 140px;
-    padding: 0 17px 12px;
+    padding: 6px 17px;
     font-family: Arial, sans-serif;
     font-size: 14px;
 }
 
-/* The heading keeps the type and the box of the button it replaces, so the word
-   "ルート" holds still across the switch and only the rest unfolds under it. */
+/* The heading keeps the type of the button it replaces and starts at the same
+   left edge. It does not keep the button's vertical box: the row is as tall as
+   the buttons in it, so the word "ルート" sits lower once the box opens. */
 h2.route-control-heading {
     margin: 0;
-    height: 40px;
-    line-height: 40px;
     font-family: Roboto, Arial, sans-serif;
     font-size: 18px;
     font-weight: normal;
+    white-space: nowrap;
 }
 
 span.route-control-count {
     font-weight: bold;
+    white-space: nowrap;
 }
 
 /* Taller than the 40px of the map's controls: these are tap targets, and they
    sit inside the box rather than lined up with that column. */
 div.route-control-panel button {
+    flex: none;
     height: 44px;
     padding: 0 16px;
     border-radius: 4px;

--- a/src/frontend/components/RouteControl.test.tsx
+++ b/src/frontend/components/RouteControl.test.tsx
@@ -63,7 +63,7 @@ describe('RouteControl', () => {
         );
 
         expect(screen.getByText('ルート')).toBeTruthy();
-        expect(screen.queryByText('ルートを作成')).toBeNull();
+        expect(screen.queryByText('作成')).toBeNull();
     });
 
     it('reports the way in', () => {
@@ -92,7 +92,7 @@ describe('RouteControl', () => {
 
         expect(leftTop(mockMap)).toHaveLength(1);
         expect(leftTop(mockMap)[0]).toBe(box);
-        expect(screen.getByText('ルートを作成')).toBeTruthy();
+        expect(screen.getByText('作成')).toBeTruthy();
     });
 
     it('reports the stop count against the limit', () => {
@@ -116,7 +116,7 @@ describe('RouteControl', () => {
             <RouteControl map={mockMap} active={true} stops={stops} onEnter={() => {}} onClose={() => {}} />,
             mockMap
         );
-        fireEvent.click(screen.getByText('ルートを作成'));
+        fireEvent.click(screen.getByText('作成'));
 
         expect(openSpy).toHaveBeenCalledWith(buildDirectionsURL(stops), '_blank', 'noopener');
     });
@@ -135,7 +135,9 @@ describe('RouteControl', () => {
             mockMap
         );
 
-        expect((screen.getByText('ルートを作成') as HTMLButtonElement).disabled).toBe(true);
+        // By its accessible name: the visible label is shortened to fit the
+        // row, and the full wording only survives in aria-label.
+        expect((screen.getByLabelText('ルートを作成') as HTMLButtonElement).disabled).toBe(true);
     });
 
     it('offers the directions once two stops are in', () => {
@@ -147,7 +149,7 @@ describe('RouteControl', () => {
             mockMap
         );
 
-        expect((screen.getByText('ルートを作成') as HTMLButtonElement).disabled).toBe(false);
+        expect((screen.getByText('作成') as HTMLButtonElement).disabled).toBe(false);
     });
 
     it('asks to leave route mode', () => {

--- a/src/frontend/components/RouteControl.tsx
+++ b/src/frontend/components/RouteControl.tsx
@@ -55,13 +55,17 @@ export function RouteControl({ map, active, stops, onEnter, onClose }: RouteCont
                 <span className="route-control-count">
                     {stops.length} / {MAX_ROUTE_SELECTION}
                 </span>
+                {/* "作成" rather than "ルートを作成": the row has a width to
+                    stay inside, spelled out in the CSS. The accessible name
+                    carries the full wording. */}
                 <button
                     type="button"
                     className="route-control-create"
+                    aria-label="ルートを作成"
                     disabled={stops.length < 2}
                     onClick={() => window.open(buildDirectionsURL(stops), '_blank', 'noopener')}
                 >
-                    ルートを作成
+                    作成
                 </button>
                 <button type="button" className="route-control-close" onClick={onClose}>
                     終了


### PR DESCRIPTION
Follow-up to #392. The panel that opens in route mode was a stacked column; it is now a single row.

## Summary

After #392 the route control was one box in one place, but in route mode it stacked its heading, stop count and two buttons into a 175 × 180px column down the left side of the map. This lays those items out in a row instead: **266 × 56px**, which covers less of the map (≈18,000px² against ≈31,500px²) and reads as the entry button extended sideways rather than as a second surface.

## Fitting the row next to the legend

`StationCounter` is pinned to the map's opposite corner (RIGHT_TOP), so the width available to the row shrinks with the screen. Measured against the current build on a 393px phone, the legend's left edge is at CSS x = 313px and the box starts at x = 10px, leaving **303px**; on a 375px phone the same measurement leaves **285px**.

Row widths measured against the real CSS:

| Row | Width | Fits 285px? |
|---|---|---|
| ルート ／ 3 / 9 ／ **ルートを作成** ／ 終了 | 327px | no — 42px over |
| ルート ／ 3 / 9 ／ ルートを作成 ／ ✕ | 310px | no |
| ルート ／ 3 / 9 ／ **作成** ／ 終了 | **266px** | yes — 19px to spare |

Shortening the primary button is what buys the row its place, so the visible label is now `作成`. An `aria-label="ルートを作成"` keeps the full wording as the button's accessible name, and the visible label is contained in it (WCAG 2.5.3).

**Below about 360px the row and the legend would meet.** No layout is added for that: 320px-class devices are out of the range this was measured for, and the CSS comment says so rather than implying the row always fits.

## Changes

- **`html/css/basic.css`**
  - `div.route-control-panel`: `flex-direction: column` and `min-width` dropped, `align-items: center` added, padding `0 17px 12px` → `6px 17px`. The 6px is the vertical padding the pre-#392 `div.route-bar` used with the same 44px buttons; the 17px matches `button.route-control-enter` so the heading keeps its left edge.
  - `h2.route-control-heading`: the 40px line box is gone, `white-space: nowrap` added. The heading no longer holds its vertical position across the switch — the row is as tall as the buttons in it, so the word sits 8px lower once the box opens. The comment says this rather than the reverse.
  - `div.route-control-panel button`: `flex: none`, so the buttons do not absorb the shrink instead of the row overflowing visibly.

- **`src/frontend/components/RouteControl.tsx`**: the create button's visible label and its `aria-label`, with a note pointing at the width constraint that the CSS spells out.

- **`src/frontend/components/RouteControl.test.tsx`**: the assertions that reached the button by its visible text now use `作成`, and the disabled-state case reaches it by its accessible name (`getByLabelText('ルートを作成')`) so the `aria-label` cannot be dropped silently. No cases added or removed.

## Verification

`npm run lint` (19 warnings, same count as master) / `npm run format` / `npm run typecheck` / `npm test` (397 passed, 6 skipped).

Removing the `aria-label` was checked to fail the disabled-state test, so that assertion guards what it claims to.

**Not verified on a real map**: the Google Maps API cannot be loaded from this environment's browser. The widths above were measured by rendering the real CSS in Chromium, and the control positions were taken from a device screenshot of the current build. Two caveats follow from that: the glyph widths are Chromium's rather than iOS's (the 19px of slack on a 375px phone absorbs the difference), and the placement itself still rests on the screenshot rather than on a live map.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGXLpQyq2SsMBzVqXX2gCE)_