### PR TITLE
Name both map modes, and read one list of picks by the mode

### DIFF
--- a/src/frontend/components/Markers.test.tsx
+++ b/src/frontend/components/Markers.test.tsx
@@ -15,6 +15,7 @@ import {
 import { MARKER_ICONS } from '../marker-icons';
 import { isCustomPoint, MAX_ROUTE_SELECTION } from '../route';
 import { MemoryStorage } from '../storage/memory-storage';
+import type { MapMode } from '../types/station-map';
 import {
     applyMultiSelection,
     changeStyle,
@@ -47,36 +48,27 @@ const buildMapClickEvent = (modifier?: 'meta' | 'ctrl', lat = 36.5, lng = 140.5)
     }) as google.maps.MapMouseEvent;
 
 describe('Markers', () => {
-    const renderMarkers = (
-        overrides: {
-            multiSelected?: google.maps.Data.Feature[];
-            selectedFeature?: google.maps.Data.Feature | null;
-            routeMode?: boolean;
-        } = {}
-    ) => {
+    const renderMarkers = (overrides: { mode?: MapMode; selected?: google.maps.Data.Feature[] } = {}) => {
         const mockMap = createMockMap();
-        const onMultiSelectChange = vi.fn();
-        const onFeatureSelect = vi.fn();
+        const onSelectedChange = vi.fn();
         const onEnterRouteMode = vi.fn();
         render(
             <Markers
                 map={mockMap}
-                selectedFeature={overrides.selectedFeature ?? null}
-                onFeatureSelect={onFeatureSelect}
-                multiSelected={overrides.multiSelected ?? []}
-                onMultiSelectChange={onMultiSelectChange}
+                mode={overrides.mode ?? 'normal'}
+                selected={overrides.selected ?? []}
+                onSelectedChange={onSelectedChange}
                 storage={new MemoryStorage()}
                 stations={stations}
                 onStyleChange={() => {}}
-                routeMode={overrides.routeMode ?? false}
                 onEnterRouteMode={onEnterRouteMode}
             />
         );
-        return { mockMap, onMultiSelectChange, onFeatureSelect, onEnterRouteMode };
+        return { mockMap, onSelectedChange, onEnterRouteMode };
     };
 
-    // Read back the selection a handler asked for, by running the updater it
-    // handed to onMultiSelectChange against the selection it started from.
+    // Read back the picks a handler asked for, by running the updater it handed
+    // to onSelectedChange against the picks it started from.
     const applyUpdater = (
         mock: ReturnType<typeof vi.fn>,
         prev: google.maps.Data.Feature[]
@@ -91,14 +83,12 @@ describe('Markers', () => {
         const { container } = render(
             <Markers
                 map={mockMap}
-                selectedFeature={null}
-                onFeatureSelect={() => {}}
-                multiSelected={[]}
-                onMultiSelectChange={() => {}}
+                mode="normal"
+                selected={[]}
+                onSelectedChange={() => {}}
                 storage={new MemoryStorage()}
                 stations={stations}
                 onStyleChange={() => {}}
-                routeMode={false}
                 onEnterRouteMode={() => {}}
             />
         );
@@ -110,14 +100,12 @@ describe('Markers', () => {
         render(
             <Markers
                 map={mockMap}
-                selectedFeature={null}
-                onFeatureSelect={() => {}}
-                multiSelected={[]}
-                onMultiSelectChange={() => {}}
+                mode="normal"
+                selected={[]}
+                onSelectedChange={() => {}}
                 storage={new MemoryStorage()}
                 stations={stations}
                 onStyleChange={() => {}}
-                routeMode={false}
                 onEnterRouteMode={() => {}}
             />
         );
@@ -132,14 +120,12 @@ describe('Markers', () => {
         const { unmount } = render(
             <Markers
                 map={mockMap}
-                selectedFeature={null}
-                onFeatureSelect={() => {}}
-                multiSelected={[]}
-                onMultiSelectChange={() => {}}
+                mode="normal"
+                selected={[]}
+                onSelectedChange={() => {}}
                 storage={new MemoryStorage()}
                 stations={stations}
                 onStyleChange={() => {}}
-                routeMode={false}
                 onEnterRouteMode={() => {}}
             />
         );
@@ -162,13 +148,12 @@ describe('Markers', () => {
         // the resolved intent must flow through the props correctly.
         it('dispatches the resolved click intent through props', () => {
             const featureB = createMockFeature('B');
-            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers();
+            const { mockMap, onSelectedChange } = renderMarkers();
 
             mockMap.data._emit('click', buildClickEvent(featureB));
 
-            expect(onFeatureSelect).toHaveBeenCalledWith(featureB);
-            // Outside route mode there is no route for a click to touch.
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
+            // Normal mode picks the one station whose details are open.
+            expect(applyUpdater(onSelectedChange, [])).toEqual([featureB]);
         });
 
         it('cycles the style on a double-click', () => {
@@ -185,11 +170,12 @@ describe('Markers', () => {
 
         it('resets the style on a right-click', () => {
             const featureB = createMockFeature('B');
-            const { mockMap, onFeatureSelect } = renderMarkers();
+            const { mockMap, onSelectedChange } = renderMarkers({ selected: [featureB] });
 
             mockMap.data._emit('rightclick', buildClickEvent(featureB));
 
-            expect(onFeatureSelect).toHaveBeenCalledWith(null);
+            // The station whose style was reset is put away with it.
+            expect(applyUpdater(onSelectedChange, [featureB])).toEqual([]);
         });
     });
 
@@ -204,14 +190,13 @@ describe('Markers', () => {
 
         it('opens the mode with the station a Cmd + click landed on', () => {
             const featureA = createMockFeature('A');
-            const { mockMap, onEnterRouteMode, onMultiSelectChange, onFeatureSelect } = renderMarkers();
+            const { mockMap, onEnterRouteMode, onSelectedChange } = renderMarkers();
 
             mockMap.data._emit('click', buildClickEvent(featureA, 'meta'));
 
             expect(onEnterRouteMode).toHaveBeenCalledWith(featureA);
-            // The mode owns the route from here; the click itself edits nothing.
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
-            expect(onFeatureSelect).not.toHaveBeenCalled();
+            // The way in owns the seed from here; the click itself picks nothing.
+            expect(onSelectedChange).not.toHaveBeenCalled();
         });
 
         it('opens the mode with a point where a Ctrl + double-click landed', () => {
@@ -236,7 +221,7 @@ describe('Markers', () => {
 
         it('is not a way in once already inside: the modifier is not read there', () => {
             const featureA = createMockFeature('A');
-            const { mockMap, onEnterRouteMode, onMultiSelectChange } = renderMarkers({ routeMode: true });
+            const { mockMap, onEnterRouteMode, onSelectedChange } = renderMarkers({ mode: 'route' });
 
             mockMap.data._emit('click', buildClickEvent(featureA, 'meta'));
             mockMap._emit('dblclick', buildMapClickEvent('ctrl'));
@@ -244,7 +229,7 @@ describe('Markers', () => {
             expect(onEnterRouteMode).not.toHaveBeenCalled();
             expect(mockMap.data.add).not.toHaveBeenCalled();
             // The marker click is an ordinary route edit, modifier or not.
-            expect(applyUpdater(onMultiSelectChange, [])).toEqual([featureA]);
+            expect(applyUpdater(onSelectedChange, [])).toEqual([featureA]);
         });
     });
 
@@ -255,22 +240,19 @@ describe('Markers', () => {
 
         it('keeps the point when the click closes a drag of it', () => {
             const point = createMockCustomPoint();
-            const { mockMap, onMultiSelectChange } = renderMarkers({
-                multiSelected: [point],
-                routeMode: true,
-            });
+            const { mockMap, onSelectedChange } = renderMarkers({ mode: 'route', selected: [point] });
 
             mockMap.data._emit('mousedown', buildClickEvent(point));
             mockMap.data._emit('setgeometry', { feature: point });
             mockMap.data._emit('click', buildClickEvent(point));
 
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
+            expect(onSelectedChange).not.toHaveBeenCalled();
 
             // The press that starts the next gesture clears the drag.
             mockMap.data._emit('mousedown', buildClickEvent(point));
             mockMap.data._emit('click', buildClickEvent(point));
 
-            expect(onMultiSelectChange).toHaveBeenCalledTimes(1);
+            expect(onSelectedChange).toHaveBeenCalledTimes(1);
         });
 
         it('stops the map from zooming while the modifier is held', () => {
@@ -302,7 +284,7 @@ describe('Markers', () => {
         });
 
         it('leaves the map its double-click zoom inside route mode', () => {
-            const { mockMap } = renderMarkers({ routeMode: true });
+            const { mockMap } = renderMarkers({ mode: 'route' });
 
             fireEvent.keyDown(window, { key: 'Control', ctrlKey: true });
 
@@ -318,43 +300,31 @@ describe('Markers', () => {
         it('adds a plainly tapped marker to the route', () => {
             const featureA = createMockFeature('A');
             const featureB = createMockFeature('B');
-            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({
-                multiSelected: [featureA],
-                routeMode: true,
-            });
+            const { mockMap, onSelectedChange } = renderMarkers({ mode: 'route', selected: [featureA] });
 
             mockMap.data._emit('click', buildClickEvent(featureB));
 
-            expect(applyUpdater(onMultiSelectChange, [featureA])).toEqual([featureA, featureB]);
-            // The info window is already closed in route mode; nothing reopens it.
-            expect(onFeatureSelect).not.toHaveBeenCalled();
+            expect(applyUpdater(onSelectedChange, [featureA])).toEqual([featureA, featureB]);
         });
 
         it('takes a marker back out of the route when it is tapped again', () => {
             const featureA = createMockFeature('A');
             const featureB = createMockFeature('B');
-            const { mockMap, onMultiSelectChange } = renderMarkers({
-                multiSelected: [featureA, featureB],
-                routeMode: true,
-            });
+            const { mockMap, onSelectedChange } = renderMarkers({ mode: 'route', selected: [featureA, featureB] });
 
             mockMap.data._emit('click', buildClickEvent(featureA));
 
-            expect(applyUpdater(onMultiSelectChange, [featureA, featureB])).toEqual([featureB]);
+            expect(applyUpdater(onSelectedChange, [featureA, featureB])).toEqual([featureB]);
         });
 
         it('leaves the visit styles alone on a double tap', () => {
             const featureA = createMockFeature('A');
-            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({
-                multiSelected: [featureA],
-                routeMode: true,
-            });
+            const { mockMap, onSelectedChange } = renderMarkers({ mode: 'route', selected: [featureA] });
             (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
 
             mockMap.data._emit('dblclick', buildClickEvent(featureA));
 
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
-            expect(onFeatureSelect).not.toHaveBeenCalled();
+            expect(onSelectedChange).not.toHaveBeenCalled();
             expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
         });
 
@@ -362,36 +332,87 @@ describe('Markers', () => {
             const featureA = createMockFeature('A');
             const featureB = createMockFeature('B');
             const featureC = createMockFeature('C');
-            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({
-                multiSelected: [featureA, featureB, featureC],
-                routeMode: true,
+            const { mockMap, onSelectedChange } = renderMarkers({
+                mode: 'route',
+                selected: [featureA, featureB, featureC],
             });
             (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
 
             mockMap.data._emit('rightclick', buildClickEvent(featureC));
 
-            expect(applyUpdater(onMultiSelectChange, [featureA, featureB, featureC])).toEqual([
+            expect(applyUpdater(onSelectedChange, [featureA, featureB, featureC])).toEqual([
                 featureA,
                 featureC,
                 featureB,
             ]);
             // Reordering is not a visit-style change.
-            expect(onFeatureSelect).not.toHaveBeenCalled();
             expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
         });
 
         it('takes no more stops once the route is full', () => {
             const full = Array.from({ length: MAX_ROUTE_SELECTION }, (_, i) => createMockFeature(`${i}`));
             const extra = createMockFeature('extra');
-            const { mockMap, onMultiSelectChange, onFeatureSelect } = renderMarkers({
-                multiSelected: full,
-                routeMode: true,
-            });
+            const { mockMap, onSelectedChange } = renderMarkers({ mode: 'route', selected: full });
 
             mockMap.data._emit('click', buildClickEvent(extra));
 
-            expect(onMultiSelectChange).not.toHaveBeenCalled();
-            expect(onFeatureSelect).not.toHaveBeenCalled();
+            expect(onSelectedChange).not.toHaveBeenCalled();
+        });
+    });
+
+    // What the map is told to draw is derived from the mode, not read off
+    // `selected`. The first of these holds that leaving the mode reaches the map
+    // as a change to apply rather than a redraw to skip; the second holds the
+    // derivation itself, since `selected` on its own would number a station
+    // whose details were merely opened.
+    describe('what the map is told to draw', () => {
+        beforeEach(() => {
+            setupGoogleMapsMock();
+        });
+
+        it('takes the route off the map when route mode is left', () => {
+            const mockMap = createMockMap();
+            const station = createMockFeature('A');
+            const point = createMockCustomPoint();
+            const props = {
+                map: mockMap,
+                onSelectedChange: () => {},
+                storage: new MemoryStorage(),
+                stations,
+                onStyleChange: () => {},
+                onEnterRouteMode: () => {},
+            };
+
+            const { rerender } = render(<Markers {...props} mode="route" selected={[station, point]} />);
+            (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
+
+            rerender(<Markers {...props} mode="normal" selected={[]} />);
+
+            // The dropped point leaves the map, and the station takes its stored
+            // icon back in place of its number.
+            expect(mockMap.data.remove).toHaveBeenCalledWith(point);
+            expect(mockMap.data.overrideStyle).toHaveBeenCalledWith(station, { icon: MARKER_ICONS[0] });
+        });
+
+        it('numbers nothing in normal mode: a station opened there is not a stop', () => {
+            const mockMap = createMockMap();
+            const station = createMockFeature('A');
+            const props = {
+                map: mockMap,
+                mode: 'normal' as MapMode,
+                onSelectedChange: () => {},
+                storage: new MemoryStorage(),
+                stations,
+                onStyleChange: () => {},
+                onEnterRouteMode: () => {},
+            };
+
+            const { rerender } = render(<Markers {...props} selected={[]} />);
+            (mockMap.data.overrideStyle as ReturnType<typeof vi.fn>).mockClear();
+
+            rerender(<Markers {...props} selected={[station]} />);
+
+            expect(mockMap.data.overrideStyle).not.toHaveBeenCalled();
         });
     });
 
@@ -402,14 +423,12 @@ describe('Markers', () => {
 
         const props = {
             map: mockMap,
-            selectedFeature: null as google.maps.Data.Feature | null,
-            onFeatureSelect: vi.fn(),
-            multiSelected: [] as google.maps.Data.Feature[],
-            onMultiSelectChange: vi.fn(),
+            mode: 'normal' as MapMode,
+            selected: [] as google.maps.Data.Feature[],
+            onSelectedChange: vi.fn(),
             storage: new MemoryStorage(),
             stations,
             onStyleChange: vi.fn(),
-            routeMode: false,
             onEnterRouteMode: vi.fn(),
         };
 
@@ -432,15 +451,9 @@ describe('resolveMarkerClick', () => {
             const a = createMockFeature('A');
             const b = createMockFeature('B');
 
-            const result = resolveMarkerClick({
-                clickedFeature: b,
-                routeMode: true,
-                selectedFeature: null,
-                multiSelected: [a],
-            });
+            const result = resolveMarkerClick('route', [a], b);
 
-            expect(result.multiSelected).toEqual([a, b]);
-            expect(result.selectedFeature).toBeUndefined();
+            expect(result.selected).toEqual([a, b]);
             expect(result.cycleStyleOn).toBeUndefined();
         });
 
@@ -448,90 +461,57 @@ describe('resolveMarkerClick', () => {
             const a = createMockFeature('A');
             const b = createMockFeature('B');
 
-            const result = resolveMarkerClick({
-                clickedFeature: a,
-                routeMode: true,
-                selectedFeature: null,
-                multiSelected: [a, b],
-            });
+            const result = resolveMarkerClick('route', [a, b], a);
 
-            expect(result.multiSelected).toEqual([b]);
+            expect(result.selected).toEqual([b]);
         });
 
         it('takes a custom point back out the same way a station goes', () => {
             const a = createMockFeature('A');
             const point = createMockCustomPoint();
 
-            const result = resolveMarkerClick({
-                clickedFeature: point,
-                routeMode: true,
-                selectedFeature: null,
-                multiSelected: [a, point],
-            });
+            const result = resolveMarkerClick('route', [a, point], point);
 
-            expect(result.multiSelected).toEqual([a]);
+            expect(result.selected).toEqual([a]);
         });
 
         it('leaves a full route untouched', () => {
             const existing = Array.from({ length: MAX_ROUTE_SELECTION }, (_, i) => createMockFeature(`${i}`));
             const extra = createMockFeature('extra');
 
-            const result = resolveMarkerClick({
-                clickedFeature: extra,
-                routeMode: true,
-                selectedFeature: null,
-                multiSelected: existing,
-            });
+            const result = resolveMarkerClick('route', existing, extra);
 
             expect(result).toEqual({});
         });
     });
 
-    describe('outside route mode', () => {
-        it('single-selects the clicked feature', () => {
+    describe('in normal mode', () => {
+        it('opens the clicked feature', () => {
             const b = createMockFeature('B');
 
-            const result = resolveMarkerClick({
-                clickedFeature: b,
-                routeMode: false,
-                selectedFeature: null,
-                multiSelected: [],
-            });
+            const result = resolveMarkerClick('normal', [], b);
 
-            expect(result.selectedFeature).toBe(b);
-            expect(result.multiSelected).toBeUndefined();
+            expect(result.selected).toEqual([b]);
             expect(result.cycleStyleOn).toBeUndefined();
         });
 
-        it('cycles the style when re-clicking the currently selected feature', () => {
+        it('cycles the style when re-clicking the feature already open', () => {
             const a = createMockFeature('A');
 
-            const result = resolveMarkerClick({
-                clickedFeature: a,
-                routeMode: false,
-                selectedFeature: a,
-                multiSelected: [],
-            });
+            const result = resolveMarkerClick('normal', [a], a);
 
             expect(result.cycleStyleOn).toBe(a);
-            expect(result.selectedFeature).toBeUndefined();
-            expect(result.multiSelected).toBeUndefined();
+            expect(result.selected).toBeUndefined();
         });
 
-        it('single-selects a different feature without touching style', () => {
+        it('opens a different feature without touching style', () => {
             const a = createMockFeature('A');
             const b = createMockFeature('B');
 
-            const result = resolveMarkerClick({
-                clickedFeature: b,
-                routeMode: false,
-                selectedFeature: a,
-                multiSelected: [],
-            });
+            const result = resolveMarkerClick('normal', [a], b);
 
-            expect(result.selectedFeature).toBe(b);
+            expect(result.selected).toEqual([b]);
             expect(result.cycleStyleOn).toBeUndefined();
-            expect(result.multiSelected).toBeUndefined();
         });
     });
 });

--- a/src/frontend/components/Markers.tsx
+++ b/src/frontend/components/Markers.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react';
-
 import { MARKER_ICONS, numberedMarkerIcon } from '../marker-icons';
 import { hasPointAt, isCustomPoint, isRouteFull } from '../route';
 import type { Storage } from '../storage';
 import * as style from '../style';
 import { getStyle } from '../style';
 import type { StationsGeoJSON } from '../types/geojson';
+import type { MapMode } from '../types/station-map';
 import { useModifierHeld } from '../use-modifier-held';
 
 // Add a custom route point at `position` and return its feature. It is created
@@ -32,44 +32,34 @@ export function dropRoutePoint(
     return [...multiSelected, addCustomPoint(map, position)];
 }
 
-export interface MarkerClickContext {
-    clickedFeature: google.maps.Data.Feature;
-    routeMode: boolean;
-    selectedFeature: google.maps.Data.Feature | null;
-    multiSelected: google.maps.Data.Feature[];
-}
-
 // `undefined` fields mean "no change".
 export interface MarkerClickResult {
-    selectedFeature?: google.maps.Data.Feature;
-    multiSelected?: google.maps.Data.Feature[];
+    selected?: google.maps.Data.Feature[];
     cycleStyleOn?: google.maps.Data.Feature;
 }
 
-// What a click on a marker does. The mode decides, and nothing else does: a
-// route only exists inside route mode, and a single selection only outside it,
-// so the two halves never have to undo each other's state.
-export function resolveMarkerClick({
-    clickedFeature,
-    routeMode,
-    selectedFeature,
-    multiSelected,
-}: MarkerClickContext): MarkerClickResult {
-    if (routeMode) {
-        if (multiSelected.includes(clickedFeature)) {
-            return { multiSelected: multiSelected.filter((feature) => feature !== clickedFeature) };
+// What a click on a marker does. It never changes the mode, only what is picked
+// in it.
+export function resolveMarkerClick(
+    mode: MapMode,
+    selected: google.maps.Data.Feature[],
+    clickedFeature: google.maps.Data.Feature
+): MarkerClickResult {
+    if (mode === 'route') {
+        if (selected.includes(clickedFeature)) {
+            return { selected: selected.filter((stop) => stop !== clickedFeature) };
         }
         // A full route takes no more, and says so by leaving the click alone.
-        if (isRouteFull(multiSelected)) {
+        if (isRouteFull(selected)) {
             return {};
         }
-        return { multiSelected: [...multiSelected, clickedFeature] };
+        return { selected: [...selected, clickedFeature] };
     }
 
-    if (selectedFeature === clickedFeature) {
+    if (selected[0] === clickedFeature) {
         return { cycleStyleOn: clickedFeature };
     }
-    return { selectedFeature: clickedFeature };
+    return { selected: [clickedFeature] };
 }
 
 // Move `feature` one number earlier in the route order, wrapping the first
@@ -198,24 +188,25 @@ export function applyMultiSelection(
 
 interface MarkersProps {
     map: google.maps.Map | null;
-    selectedFeature: google.maps.Data.Feature | null;
-    onFeatureSelect: (feature: google.maps.Data.Feature | null) => void;
-    multiSelected: google.maps.Data.Feature[];
-    onMultiSelectChange: (update: (prev: google.maps.Data.Feature[]) => google.maps.Data.Feature[]) => void;
+    mode: MapMode;
+    selected: google.maps.Data.Feature[];
+    onSelectedChange: (update: (prev: google.maps.Data.Feature[]) => google.maps.Data.Feature[]) => void;
     storage: Storage;
     stations: StationsGeoJSON | null;
     onStyleChange: () => void;
-    routeMode: boolean;
-    // Called by the modifier gestures, which are the shortcut into route mode:
-    // the mode opens with `seed` as its first stop.
+    // Called by the modifier gestures, which open the mode with `seed` in it.
     onEnterRouteMode: (seed: google.maps.Data.Feature) => void;
 }
 
 export function Markers(props: MarkersProps) {
-    const selectedFeatureRef = useRef<google.maps.Data.Feature | null>(null);
-    const multiSelectedRef = useRef<google.maps.Data.Feature[]>(props.multiSelected);
+    // The listeners are installed once, so what they read has to come from a ref
+    // rather than the render they were created in.
+    const modeRef = useRef<MapMode>(props.mode);
+    const selectedRef = useRef<google.maps.Data.Feature[]>(props.selected);
+    // The stops as the map currently draws them, which the next change diffs
+    // against to know which markers to re-number and which to take off.
+    const drawnStopsRef = useRef<google.maps.Data.Feature[]>([]);
     const storageRef = useRef<Storage>(props.storage);
-    const routeModeRef = useRef<boolean>(props.routeMode);
     // Set when a drag moved a custom point, cleared by the next press on a
     // marker. Dragging a point ends with a mouseup on it, and a click on a
     // chosen marker takes it back out of the route, so the release that finishes
@@ -225,12 +216,9 @@ export function Markers(props: MarkersProps) {
     const modifierHeld = useModifierHeld();
 
     useEffect(() => {
-        selectedFeatureRef.current = props.selectedFeature;
-    }, [props.selectedFeature]);
-
-    useEffect(() => {
-        routeModeRef.current = props.routeMode;
-    }, [props.routeMode]);
+        modeRef.current = props.mode;
+        selectedRef.current = props.selected;
+    }, [props.mode, props.selected]);
 
     // Keep handlers and the data-layer style callback bound to the latest storage
     // so login/logout transitions immediately switch storage backends without remounting.
@@ -263,27 +251,23 @@ export function Markers(props: MarkersProps) {
         return () => listener.remove();
     }, [props.map]);
 
-    // Outside route mode the modifier turns a double-click into "start a route
-    // here", so the map must not read the same gesture as a zoom-in while it is
-    // held. Inside the mode the modifier is not read at all, and the map keeps
-    // its double-click.
+    // The modifier turns a double-click into the way into route mode, so the map
+    // must not read the same gesture as a zoom-in while it is held.
     useEffect(() => {
-        props.map?.setOptions({ disableDoubleClickZoom: modifierHeld && !props.routeMode });
-    }, [props.map, modifierHeld, props.routeMode]);
+        props.map?.setOptions({ disableDoubleClickZoom: modifierHeld && props.mode === 'normal' });
+    }, [props.map, modifierHeld, props.mode]);
 
     useEffect(() => {
         if (!props.map) return;
-        applyMultiSelection(props.map, multiSelectedRef.current, props.multiSelected, storageRef.current);
-        multiSelectedRef.current = props.multiSelected;
-    }, [props.map, props.multiSelected]);
+        const stops = props.mode === 'route' ? props.selected : [];
+        applyMultiSelection(props.map, drawnStopsRef.current, stops, storageRef.current);
+        drawnStopsRef.current = stops;
+    }, [props.map, props.mode, props.selected]);
 
     const applyClickResult = (result: MarkerClickResult) => {
-        if (result.selectedFeature !== undefined) {
-            props.onFeatureSelect(result.selectedFeature);
-        }
-        if (result.multiSelected !== undefined) {
-            const { multiSelected } = result;
-            props.onMultiSelectChange(() => multiSelected);
+        if (result.selected !== undefined) {
+            const { selected } = result;
+            props.onSelectedChange(() => selected);
         }
         if (result.cycleStyleOn && props.map) {
             changeStyle(props.map, result.cycleStyleOn, storageRef.current);
@@ -295,53 +279,36 @@ export function Markers(props: MarkersProps) {
         if (!props.map) return;
         if (draggedRef.current) return;
 
-        // Outside the mode, the modifier makes this click the way in, with the
-        // station clicked as the first stop.
-        if (!routeModeRef.current && isModifierPressed(event)) {
+        if (modeRef.current === 'normal' && isModifierPressed(event)) {
             props.onEnterRouteMode(event.feature);
             return;
         }
-        applyClickResult(
-            resolveMarkerClick({
-                clickedFeature: event.feature,
-                routeMode: routeModeRef.current,
-                selectedFeature: selectedFeatureRef.current,
-                multiSelected: multiSelectedRef.current,
-            })
-        );
+        applyClickResult(resolveMarkerClick(modeRef.current, selectedRef.current, event.feature));
     };
 
-    // Modifier + double-click on the map is the other way in, with a point at
-    // the cursor as the first stop. Inside the mode the crosshair places points
-    // and this gesture is the map's own again, so only the way in reads it.
     const onMapDoubleClick = (event: google.maps.MapMouseEvent) => {
-        if (!props.map || routeModeRef.current) return;
+        if (!props.map || modeRef.current === 'route') return;
         if (!isModifierPressed(event) || !event.latLng) return;
         props.onEnterRouteMode(addCustomPoint(props.map, event.latLng));
     };
 
     const onMarkerDoubleClick = (event: google.maps.Data.MouseEvent) => {
         if (!props.map) return;
-        // Route mode edits the route, not the visit styles: a double tap there
-        // is two taps that added and removed a stop, and cycling the style on
-        // top of that is not what was asked.
-        // A modifier + double-click is caught by the same guard: its first click
+        // A modifier + double-click is stopped here as well: its first click
         // already opened route mode.
-        if (routeModeRef.current) return;
+        if (modeRef.current === 'route') return;
         changeStyle(props.map, event.feature, storageRef.current);
         props.onStyleChange();
     };
 
     const onMarkerRightClick = (event: google.maps.Data.MouseEvent) => {
         if (!props.map) return;
-        // In route mode a gesture on a marker edits the route, and reordering is
-        // what a tap does not already do.
-        if (routeModeRef.current) {
-            props.onMultiSelectChange((prev) => cycleRouteNumber(prev, event.feature));
+        if (modeRef.current === 'route') {
+            props.onSelectedChange((prev) => cycleRouteNumber(prev, event.feature));
             return;
         }
         resetStyle(props.map, event.feature, storageRef.current);
-        props.onFeatureSelect(null);
+        props.onSelectedChange(() => []);
         props.onStyleChange();
     };
 

--- a/src/frontend/components/RoadStationMap.tsx
+++ b/src/frontend/components/RoadStationMap.tsx
@@ -5,6 +5,7 @@ import { isRouteFull } from '../route';
 import { fetchStations, reconcileVisits } from '../station';
 import { createStorage, type Storage } from '../storage';
 import type { StationsGeoJSON } from '../types/geojson';
+import type { MapMode } from '../types/station-map';
 import { InfoWindow } from './InfoWindow';
 import { LoginButton } from './LoginButton';
 import { dropRoutePoint, Markers } from './Markers';
@@ -24,20 +25,19 @@ export function RoadStationMap() {
     useSessionRefresh(authManager);
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const [map, setMap] = useState<google.maps.Map | null>(null);
-    const [feature, setFeature] = useState<google.maps.Data.Feature | null>(null);
-    const [multiSelected, setMultiSelected] = useState<google.maps.Data.Feature[]>([]);
     const [stations, setStations] = useState<StationsGeoJSON | null>(null);
     const [styleVersion, setStyleVersion] = useState(0);
     const [storage, setStorage] = useState<Storage | null>(null);
     const [loadError, setLoadError] = useState<string | null>(null);
-    const [routeMode, setRouteMode] = useState(false);
-    // The map click listener is installed once, so what it reads about route
-    // mode has to come from a ref rather than the render it was created in.
-    const routeModeRef = useRef(routeMode);
+    const [mode, setMode] = useState<MapMode>('normal');
+    const [selected, setSelected] = useState<google.maps.Data.Feature[]>([]);
+    // The map click listener is installed once, so what it reads about the mode
+    // has to come from a ref rather than the render it was created in.
+    const modeRef = useRef(mode);
 
     useEffect(() => {
-        routeModeRef.current = routeMode;
-    }, [routeMode]);
+        modeRef.current = mode;
+    }, [mode]);
 
     useEffect(() => {
         if (mapContainerRef.current) {
@@ -93,13 +93,11 @@ export function RoadStationMap() {
     useEffect(() => {
         if (!map) return;
 
-        // A tap on the map puts the open station away. In route mode it does
-        // nothing at all — the mode answers markers and its own control, not the
-        // ground between them — and the guard says so even though route mode
-        // leaves no open station for it to put away.
         map.addListener('click', () => {
-            if (routeModeRef.current) return;
-            setFeature(null);
+            if (modeRef.current === 'route') return;
+            // Handing `prev` back when nothing is open keeps the tap from
+            // re-rendering.
+            setSelected((prev) => (prev.length ? [] : prev));
         });
         getCurrentPosition().then(onLocationDetected);
     }, [map]);
@@ -111,30 +109,27 @@ export function RoadStationMap() {
         }
     };
 
-    // Open route mode. `seed` is the stop the way in came with — the switch
-    // brings none and starts an empty route, the modifier gestures bring the
-    // station or the point they landed on. Either way the info window closes:
-    // from here a tap on a marker adds it to the route rather than opening it.
     const enterRouteMode = (seed?: google.maps.Data.Feature) => {
-        setFeature(null);
-        setMultiSelected(seed ? [seed] : []);
-        setRouteMode(true);
+        setMode('route');
+        setSelected(seed ? [seed] : []);
     };
 
-    // Put a route point at the middle of the map, where the crosshair is.
+    // Put a route point at the middle of the map, where the crosshair is. The
+    // mode is checked here rather than left to the button that calls it, since
+    // this writes a pick and nothing else vouches for the mode it is written in.
     const addPointAtCenter = () => {
         const center = map?.getCenter();
-        if (!map || !center) return;
-        const route = dropRoutePoint(map, center, multiSelected);
-        if (route) setMultiSelected(route);
+        if (mode !== 'route' || !map || !center) return;
+        const stops = dropRoutePoint(map, center, selected);
+        if (stops) setSelected(stops);
     };
 
-    // Leave route mode. The route lives exactly as long as the mode, so it goes
-    // with it.
     const closeRoute = () => {
-        setRouteMode(false);
-        setMultiSelected([]);
+        setMode('normal');
+        setSelected([]);
     };
+
+    const openStation = mode === 'normal' ? (selected[0] ?? null) : null;
 
     return (
         <>
@@ -149,35 +144,35 @@ export function RoadStationMap() {
                 <>
                     <Markers
                         map={map}
-                        selectedFeature={feature}
-                        onFeatureSelect={setFeature}
-                        multiSelected={multiSelected}
-                        onMultiSelectChange={setMultiSelected}
+                        mode={mode}
+                        selected={selected}
+                        onSelectedChange={setSelected}
                         storage={storage}
                         stations={stations}
                         onStyleChange={() => setStyleVersion((v) => v + 1)}
-                        routeMode={routeMode}
                         onEnterRouteMode={enterRouteMode}
                     />
                     <ShareButton map={map} />
                     <StationCounter storage={storage} stations={stations} styleVersion={styleVersion} map={map} />
                     {/* Aimed at by panning the map, and shown only while there is
                         room for another point. */}
-                    {routeMode && !isRouteFull(multiSelected) && <div className="route-crosshair" aria-hidden="true" />}
+                    {mode === 'route' && !isRouteFull(selected) && (
+                        <div className="route-crosshair" aria-hidden="true" />
+                    )}
                     {/* Route mode rides on the markers: Markers puts them on the
                         map, numbers the chosen ones and takes the dropped points
                         off again, so there is no route to build without it. */}
                     <RouteControl
                         map={map}
-                        active={routeMode}
-                        stops={multiSelected}
+                        active={mode === 'route'}
+                        stops={selected}
                         onEnter={() => enterRouteMode()}
                         onAddPoint={addPointAtCenter}
                         onClose={closeRoute}
                     />
                 </>
             )}
-            <InfoWindow selectedFeature={feature} map={map} />
+            <InfoWindow selectedFeature={openStation} map={map} />
             <LoginButton map={map} />
         </>
     );

--- a/src/frontend/components/RouteControl.tsx
+++ b/src/frontend/components/RouteControl.tsx
@@ -5,6 +5,7 @@ import { buildDirectionsURL, isRouteFull, MAX_ROUTE_SELECTION } from '../route';
 interface RouteControlProps {
     map: google.maps.Map | null;
     active: boolean;
+    // Handed over as it stands: read as a route only while the switch is on.
     stops: google.maps.Data.Feature[];
     onEnter: () => void;
     onAddPoint: () => void;

--- a/src/frontend/types/station-map.ts
+++ b/src/frontend/types/station-map.ts
@@ -1,0 +1,6 @@
+// Domain types for the roadside-station map. The modes themselves are in
+// `docs/station-map.md`.
+
+// The mode reads one list of picks either way: at most one station in normal
+// mode, the route's stops in route mode.
+export type MapMode = 'normal' | 'route';


### PR DESCRIPTION
The station map has a normal mode and a route mode, but the code carried
the pair as a boolean, so only one of the two had a name and the other
was read off a negation. What the user had picked was split in two as
well — the station whose details are open, and the stops of the route —
each in state of its own, which entering and leaving a mode had to keep
in step with the boolean by hand.

Touching a marker is the single gesture behind both recording a visit
and adding a stop, so what it picks is now one list either way, and the
mode is what says how to read it: at most one station, the one whose
details are open, or the stops of the route in the order the route
visits them. Neither reading can be mistaken for the other, and nothing
has to cross one off against the other on the way into or out of a mode.

`RoadStationMap` holds the mode and one list of picks where those three
states stood, and `resolveMarkerClick` is handed the mode and answers
with the one list of picks, rather than choosing which of two pick
fields to write. In `Markers` the picks the handlers read and the stops
the map has drawn are two refs with one job each, where a single ref
carried both and went unwritten while the map was still loading.

## Added test cases

### src/frontend/components/Markers.test.tsx

| Context | Example | Description |
|---|---|---|
| `Markers` > `what the map is told to draw` | `takes the route off the map when route mode is left` | Leaving the mode reaches the map as a change to apply rather than a redraw to skip: the dropped points come off and the numbered stations take their stored icons back. |
| `Markers` > `what the map is told to draw` | `numbers nothing in normal mode: a station opened there is not a stop` | What is drawn is derived from the mode — reading the picks without it would number the station whose details were merely opened. |