### PR TITLE
Research 10 oldest-checked roadside station plan records

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -637,7 +637,7 @@
                 "url": "https://note.com/hibishinbun/n/nf161f99b9c34"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 しろいし",
@@ -673,7 +673,7 @@
                 "url": "https://kahoku.news/articles/20251029khn000042.html"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 栗原市",
@@ -729,7 +729,7 @@
                 "url": "https://www.tomiya-city.miyagi.jp/uploads/pdf/327731df21ce3260071f5699fbbd2774a8d1b0c5.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 やまがた蔵王",
@@ -773,7 +773,7 @@
                 "url": "http://www.jcpress.co.jp/wp01/?p=25775"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 川崎町",
@@ -813,7 +813,7 @@
                 "url": "https://www.mlit.go.jp/sogoseisaku/kanminrenkei/content/001372406.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 はちもり (移転)",
@@ -837,7 +837,7 @@
                 "url": "https://akitakenjinkai.jp/admin/wp-content/uploads/2023/10/IMG_0001-5.pdf"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 山形中央IC",
@@ -853,7 +853,7 @@
                 "url": "https://www.city.yamagata-yamagata.lg.jp/shiseijoho/keikaku/1008370/1002617.html"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅あつみ うぇるかぶ (移転)",
@@ -877,7 +877,7 @@
                 "url": "https://www.city.tsuruoka.lg.jp/seibi/nezugaseki-ic/logomark.html"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 新庄IC付近",
@@ -899,9 +899,13 @@
             {
                 "title": "令和7年度施政方針",
                 "url": "https://www.city.shinjo.yamagata.jp/s002/050/r7_shiseihoushin.html"
+            },
+            {
+                "title": "新庄ＩＣ付近道の駅検討会、来年９月に基本構想",
+                "url": "https://www.yamagata-np.jp/news/202510/29/kj_2025102900827.php"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 むらやま (移転)",
@@ -921,7 +925,7 @@
                 "url": "https://www.yamagata-np.jp/news/202606/14/kj_2026061400366.php"
             }
         ],
-        "checked_on": "2026-08-11"
+        "checked_on": "2026-08-24"
     },
     {
         "name": "道の駅 東根市",


### PR DESCRIPTION
## 調査した駅の一覧

- 道の駅 石巻市（宮城県）
- 道の駅 しろいし（宮城県）
- 道の駅 富谷市（宮城県）
- 道の駅 蔵王町（宮城県）
- 道の駅 利府町浜田地区（宮城県）
- 道の駅 はちもり (移転)（秋田県）
- 道の駅 山形中央IC（山形県）
- 道の駅あつみ うぇるかぶ (移転)（山形県）
- 道の駅 新庄IC付近（山形県）
- 道の駅 むらやま (移転)（山形県）

## 報告事項

なし（`docs/plan-reports.md` への追記は行っていません）